### PR TITLE
find sources for images after moving the site from another URL

### DIFF
--- a/includes/model.php
+++ b/includes/model.php
@@ -509,6 +509,17 @@ class ISC_Model {
 		// this is how WordPress core is detecting changed image URLs
 		$newurl = esc_url( preg_replace( "/-(?:\d+x\d+|scaled|rotated)\.{$ext}(.*)/i", '.' . $ext, $url ) );
 
+		/**
+		 * attachment_url_to_postid needs the URL including protocol, but cannot handle sizes, so it needs to be at exactly this position
+		 * this function finds images based on the _wp_attached_file post meta value that includes the image path followed after the upload dir
+		 * it therefore also works when the domain changed
+		 */
+		$id = attachment_url_to_postid( $newurl );
+		if( $id ) {
+			ISC_Log::log( '_attachment_url_to_postid found image ID ' . $id );
+			return $id;
+		}
+
 		// remove protocoll (http or https)
 		$url    = str_ireplace( array( 'http:', 'https:' ), '', $url );
 		$newurl = str_ireplace( array( 'http:', 'https:' ), '', $newurl );

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,10 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 == Changelog ==
 
+= untagged =
+
+- find sources for images after moving the site from another URL
+
 = 2.1.1 =
 
 - only load ISC-related scripts on the plugin’s admin pages


### PR DESCRIPTION
In the test case, the `guid` value from the post table included a previous URL. After the site moved, that URL was no longer valid so our checks couldn’t find it.
ISC uses `attachment_url_to_postid()` now as a first attempts for getting the image. It looks for the `_wp_attached_file` post meta data, that includes the file’s position in the `upload` folder, but not the full URL