### PR TITLE
split admin script file to load only relevant ones

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -94,8 +94,17 @@ class ISC_Admin extends ISC_Class {
 	 */
 	public function add_admin_scripts( $hook ) {
 		$screen = get_current_screen();
-		if ( isset( $screen->id ) && in_array( $screen->id, array( 'settings_page_isc-settings', 'media_page_isc-sources' ) ) ) {
-			wp_enqueue_script( 'isc_script', plugins_url( '/assets/js/isc.js', __FILE__ ), false, ISCVERSION );
+		if ( isset( $screen->id ) && $screen->id === 'settings_page_isc-settings' ) {
+			wp_enqueue_script( 'isc_settings_script', plugins_url( '/assets/js/settings.js', __FILE__ ), array(), ISCVERSION, true );
+		}
+
+		if ( isset( $screen->id ) && $screen->id === 'media_page_isc-sources' ) {
+			wp_enqueue_script( 'isc_sources_script', plugins_url( '/assets/js/sources.js', __FILE__ ), array(), ISCVERSION, true );
+		}
+
+		// load CSS
+		// todo: split CSS file to load only the relevant parts
+		if ( isset( $screen->id ) && in_array( $screen->id, array( 'settings_page_isc-settings', 'media_page_isc-sources' ), true ) ) {
 			wp_enqueue_style( 'isc_image_settings_css', plugins_url( '/assets/css/isc.css', __FILE__ ), false, ISCVERSION );
 		}
 	}

--- a/admin/assets/js/settings.js
+++ b/admin/assets/js/settings.js
@@ -1,3 +1,6 @@
+/**
+ * Scripts for Settings > Image Sources
+ */
 jQuery( document ).ready(
 	function($) {
 		isc_thumbnail_input_checkstate();
@@ -5,105 +8,6 @@ jQuery( document ).ready(
 		$( '#isc-settings-overlay-enable' ).on( 'click', function(){ isc_caption_checkstate() } );
 		$( '.isc-settings-standard-source input' ).on( 'change', isc_toggle_standard_source_text );
 		$( '#thumbnail-size-select, #use-thumbnail' ).on( 'change', function(){ isc_thumbnail_input_checkstate(); } );
-
-		// debug function – load image-post relations
-		// call post-image relation (meta fields saved for posts)
-		$( '#isc-list-post-image-relation' ).on(
-			'click',
-			function(){
-				// disable the button
-				var button      = this;
-				button.disabled = true;
-
-				$.ajax(
-					{
-						type: 'POST',
-						url: ajaxurl,
-						data: {
-							action: 'isc-post-image-relations',
-							nonce: isc.ajaxNonce,
-						},
-						success:function(data, textStatus, XMLHttpRequest){
-							// display return messages
-							$( '#isc-post-image-relations' ).html( data );
-							button.disabled = false;
-						},
-
-						error: function(MLHttpRequest, textStatus, errorThrown){
-							$( '#isc-post-image-relations' ).html( errorThrown );
-							button.disabled = false;
-						}
-
-					}
-				);
-			}
-		);
-		// call image-post relation (meta fields saved for posts)
-		$( '#isc-list-image-post-relation' ).on(
-			'click',
-			function(){
-				// disable the button
-				var button      = this;
-				button.disabled = true;
-
-				$.ajax(
-					{
-						type: 'POST',
-						url: ajaxurl,
-						data: {
-							action: 'isc-image-post-relations',
-							nonce: isc.ajaxNonce,
-						},
-						success:function(data, textStatus, XMLHttpRequest){
-							// display return messages
-							$( '#isc-image-post-relations' ).html( data );
-							button.disabled = false;
-						},
-						error: function(MLHttpRequest, textStatus, errorThrown){
-							$( '#isc-image-post-relations' ).html( errorThrown );
-							button.disabled = false;
-						}
-					}
-				);
-			}
-		);
-		// remove image-post index
-		$( '#isc-clear-index' ).on(
-			'click',
-			function(){
-
-				var areYouSure = confirm( isc_data.confirm_message );
-
-				if ( ! areYouSure ) {
-					return;
-				}
-
-				// disable the button
-				var button      = this;
-				button.disabled = true;
-
-				$.ajax(
-					{
-						type: 'POST',
-						url: ajaxurl,
-						data: {
-							action: 'isc-clear-index',
-							nonce: isc.ajaxNonce,
-						},
-						success:function(data, textStatus, XMLHttpRequest){
-							// display return messages
-							$( '#isc-clear-index-feedback' ).html( data );
-							button.disabled = false;
-						},
-						error: function(MLHttpRequest, textStatus, errorThrown){
-							$( '#isc-clear-index-feedback' ).html( errorThrown );
-							button.disabled = false;
-						}
-
-					}
-				);
-			}
-		);
 	}
 );
 

--- a/admin/assets/js/sources.js
+++ b/admin/assets/js/sources.js
@@ -1,0 +1,105 @@
+/**
+ * Scripts for Media > Image Sources
+ */
+jQuery( document ).ready(
+	function($) {
+		// debug function – load image-post relations
+		// call post-image relation (meta fields saved for posts)
+		$( '#isc-list-post-image-relation' ).on(
+			'click',
+			function(){
+				// disable the button
+				var button      = this;
+				button.disabled = true;
+
+				$.ajax(
+					{
+						type: 'POST',
+						url: ajaxurl,
+						data: {
+							action: 'isc-post-image-relations',
+							nonce: isc.ajaxNonce,
+						},
+						success:function(data, textStatus, XMLHttpRequest){
+							// display return messages
+							$( '#isc-post-image-relations' ).html( data );
+							button.disabled = false;
+						},
+
+						error: function(MLHttpRequest, textStatus, errorThrown){
+							$( '#isc-post-image-relations' ).html( errorThrown );
+							button.disabled = false;
+						}
+
+					}
+				);
+			}
+		);
+		// call image-post relation (meta fields saved for posts)
+		$( '#isc-list-image-post-relation' ).on(
+			'click',
+			function(){
+				// disable the button
+				var button      = this;
+				button.disabled = true;
+
+				$.ajax(
+					{
+						type: 'POST',
+						url: ajaxurl,
+						data: {
+							action: 'isc-image-post-relations',
+							nonce: isc.ajaxNonce,
+						},
+						success:function(data, textStatus, XMLHttpRequest){
+							// display return messages
+							$( '#isc-image-post-relations' ).html( data );
+							button.disabled = false;
+						},
+						error: function(MLHttpRequest, textStatus, errorThrown){
+							$( '#isc-image-post-relations' ).html( errorThrown );
+							button.disabled = false;
+						}
+					}
+				);
+			}
+		);
+		// remove image-post index
+		$( '#isc-clear-index' ).on(
+			'click',
+			function(){
+
+				var areYouSure = confirm( isc_data.confirm_message );
+
+				if ( ! areYouSure ) {
+					return;
+				}
+
+				// disable the button
+				var button      = this;
+				button.disabled = true;
+
+				$.ajax(
+					{
+						type: 'POST',
+						url: ajaxurl,
+						data: {
+							action: 'isc-clear-index',
+							nonce: isc.ajaxNonce,
+						},
+						success:function(data, textStatus, XMLHttpRequest){
+							// display return messages
+							$( '#isc-clear-index-feedback' ).html( data );
+							button.disabled = false;
+						},
+						error: function(MLHttpRequest, textStatus, errorThrown){
+							$( '#isc-clear-index-feedback' ).html( errorThrown );
+							button.disabled = false;
+						}
+
+					}
+				);
+			}
+		);
+	}
+);


### PR DESCRIPTION
Split `isc.js` into `sources.js` and `settings.js` which are then loaded only on the pages where they are needed.

fixes script issues caused by missing elements when settings-related scripts were loaded on the sources page.