### PR TITLE
added isc_public_source_url_html filter

### DIFF
--- a/isc.php
+++ b/isc.php
@@ -1,7 +1,7 @@
 <?php
 /*
   Plugin Name: Image Source Control
-  Version: 2.2.1
+  Version: 2.3.0
   Plugin URI: https://imagesourcecontrol.com/
   Description: Image Source Control saves the source of an image, lists them and warns if it is missing.
   Author: Thomas Maier
@@ -30,7 +30,7 @@ if ( class_exists( 'ISC_Class', false ) ) {
 	exit;
 }
 
-define( 'ISCVERSION', '2.2.1' );
+define( 'ISCVERSION', '2.3.0' );
 define( 'ISCNAME', 'Image Source Control' );
 define( 'ISCDIR', basename( dirname( __FILE__ ) ) );
 define( 'ISCPATH', plugin_dir_path( __FILE__ ) );

--- a/public/public.php
+++ b/public/public.php
@@ -977,7 +977,12 @@ class ISC_Public extends ISC_Class {
 
 		// wrap link around source, if given
 		if ( '' != $metadata['source_url'] ) {
-			$source = sprintf( '<a href="%2$s" target="_blank" rel="nofollow">%1$s</a>', $source, $metadata['source_url'] );
+			$source = apply_filters(
+				'isc_public_source_url_html',
+				sprintf( '<a href="%2$s" target="_blank" rel="nofollow">%1$s</a>', $source, $metadata['source_url'] ),
+				$id,
+				$metadata
+			);
 		}
 
 		// add license if enabled

--- a/public/public.php
+++ b/public/public.php
@@ -500,12 +500,20 @@ class ISC_Public extends ISC_Class {
 				ISC_Log::log( sprintf( 'skip image %d because of empty source', $atts_id ) );
 				continue;
 			}
-			printf( '<li>%1$s: %2$s</li>', $atts_array['title'], $atts_array['source'] );
+			echo apply_filters(
+				'isc_source_list_line',
+				sprintf( '<li>%1$s: %2$s</li>', $atts_array['title'], $atts_array['source'] ),
+				$atts_id,
+				$atts_array,
+				$attachments
+			);
 		}
 		?>
 		</ul>
 		<?php
-		return $this->render_image_source_box( ob_get_clean() );
+		$output = apply_filters( 'isc_source_list', ob_get_clean() );
+
+		return $this->render_image_source_box( $output );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 = 2.3.0 =
 
 - added `isc_source_list_line` and `isc_source_list` filter hooks to allow developers to manipulate the source list output
+- added `isc_public_source_url_html` filter to manipulate the source link HTML
 - allow source injection into content outside the loop when using Oxygen page builder
 
 = 2.2.1 =

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: webzunft
 Tags: image, images, picture, picture source, image source, bild, bilder, photo, photos, foto, media, caption, copyright
 Requires at least: 5.3
-Tested up to: 5.7
-Stable tag: 2.2.1
+Tested up to: 5.8
+Stable tag: 2.3.0
 Requires PHP: 5.6
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -100,7 +100,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 == Changelog ==
 
-= untagged =
+= 2.3.0 =
 
 - added `isc_source_list_line` and `isc_source_list` filter hooks to allow developers to manipulate the source list output
 - allow source injection into content outside the loop when using Oxygen page builder

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 = untagged =
 
+- added `isc_source_list_line` and `isc_source_list` filter hooks to allow developers to manipulate the source list output
 - allow source injection into content outside the loop when using Oxygen page builder
 
 = 2.2.1 =


### PR DESCRIPTION
Solves #120

The `isc_public_source_url_html` filter can be used to manipulate the whole HTML that creates the source link.

Examples (add to the theme’s `function.php`)

**Remove "nofollow" from all source links**

```
add_filter( 'isc_public_source_url_html', function( $source_link_html ) {
	return str_replace( 'rel="nofollow"', '', $source_link_html );
} );
```

**Remove "nofollow" only from specific images**

`array( 12, 123 )` is just an example and needs to be replaced with your own attachment IDs.

```
add_filter( 'isc_public_source_url_html', function( $source_link_html, $attachment_id ) {
	// the example works for images with the ID 12 and 123
	if( ! in_array( $attachment_id, array( 12, 123 ), true ) ) {
		return $source_link_html;
	}

	return str_replace( 'rel="nofollow"', '', $source_link_html );
}, 10, 2 );
```