### PR TITLE
added isc_source_list_line and isc_source_list filter hooks

### DIFF
--- a/public/public.php
+++ b/public/public.php
@@ -500,12 +500,20 @@ class ISC_Public extends ISC_Class {
 				ISC_Log::log( sprintf( 'skip image %d because of empty source', $atts_id ) );
 				continue;
 			}
-			printf( '<li>%1$s: %2$s</li>', $atts_array['title'], $atts_array['source'] );
+			echo apply_filters(
+				'isc_source_list_line',
+				sprintf( '<li>%1$s: %2$s</li>', $atts_array['title'], $atts_array['source'] ),
+				$atts_id,
+				$atts_array,
+				$attachments
+			);
 		}
 		?>
 		</ul>
 		<?php
-		return $this->render_image_source_box( ob_get_clean() );
+		$output = apply_filters( 'isc_source_list', ob_get_clean() );
+
+		return $this->render_image_source_box( $output );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 = untagged =
 
+- added `isc_source_list_line` and `isc_source_list` filter hooks to allow developers to manipulate the source list output
 - allow source injection into content outside the loop when using Oxygen page builder
 
 = 2.2.1 =


### PR DESCRIPTION
Added `isc_source_list_line` and `isc_source_list` filter hooks to allow developers to manipulate the source list output

See https://wordpress.org/support/topic/gekurzte-bildquellenangaben/