### PR TITLE
Tighten security checks when updating post meta via AJAX

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 = untagged =
 
 - fixed AMP validation errors
+- prevent contributors from updating unrelated post meta, props to wpscan
 
 = 2.3.0 =
 
@@ -207,7 +208,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 = 1.9.1 =
 
 * delayed displaying source overlay by 100 ms to give images a chance to load their height
-* fixed wrong height of the overlay being used 
+* fixed wrong height of the overlay being used
 * fixed missing textdomain code to allow translations added through wordpress.org
 
 = 1.9 =


### PR DESCRIPTION
Contributors and higher roles were able to change any post meta information with explicit custom code.
This PR restricts such access to ISC post meta fields and posts, to which the current user has access.