### PR TITLE
Fix to overlay placement RegExp pattern

### DIFF
--- a/public/public.php
+++ b/public/public.php
@@ -246,6 +246,8 @@ class ISC_Public extends ISC_Class {
 		 *
 		 * potential issues:
 		 * * line breaks in the code – use \s* where potential line breaks could appear
+		 *
+		 * Use (\x20|\x9|\xD|\xA)+ to match whitespace following HTML starting tag name according to W3C REC 3.1. See issue PR #136
 		 */
 		$pattern = '#(<[^>]*class="[^"]*(alignleft|alignright|alignnone|aligncenter).*)?((<a[\x20|\x9|\xD|\xA]+[^>]*(rel="[^"]*[^"]*wp-att-(\d+)"[^>]*)*>)?\s*(<img[\x20|\x9|\xD|\xA]+[^>]*[^>]*src="(.+)".*\/?>).*(\s*</a>)??[^<]*).*(<\/figure.*>)?#isU';
 

--- a/public/public.php
+++ b/public/public.php
@@ -247,7 +247,7 @@ class ISC_Public extends ISC_Class {
 		 * potential issues:
 		 * * line breaks in the code – use \s* where potential line breaks could appear
 		 */
-		$pattern = '#(<[^>]*class="[^"]*(alignleft|alignright|alignnone|aligncenter).*)?((<a [^>]*(rel="[^"]*[^"]*wp-att-(\d+)"[^>]*)*>)?\s*(<img [^>]*[^>]*src="(.+)".*\/?>).*(\s*</a>)??[^<]*).*(<\/figure.*>)?#isU';
+		$pattern = '#(<[^>]*class="[^"]*(alignleft|alignright|alignnone|aligncenter).*)?((<a[\x20|\x9|\xD|\xA]+[^>]*(rel="[^"]*[^"]*wp-att-(\d+)"[^>]*)*>)?\s*(<img[\x20|\x9|\xD|\xA]+[^>]*[^>]*src="(.+)".*\/?>).*(\s*</a>)??[^<]*).*(<\/figure.*>)?#isU';
 
 		$match_content = apply_filters( 'isc_public_caption_regex_content', $content );
 


### PR DESCRIPTION
The overlay placement function RegExp pattern expects a space character after the HTML tag name in two instances which is in contradiction to W3C REC 3.1. Hence, any image that is placed with any other whitespace character but space after the tag name in the start tag doesn’t match the pattern and isn’t recognized by the overlay placement script.

A W3C REC-conforming sample piece of code **not** matching the pattern would be:
```
<img
src="https://example.com/example.gif" />
```

The W3C REC allows the starting tag’s name to be followed by space, character tabulation, (obsolete) carriage return or line feed – see [https://www.w3.org/TR/REC-xml/#NT-S](https://www.w3.org/TR/REC-xml/#NT-S)
`(#x20 | #x9 | #xD | #xA)+`

I replaced the space character after both the “a” and “img” part with this character list followed by the “+” multiplier for the pattern to adhere to W3C REC 3.1:
`[\x20|\x9|\xD|\xA]+`

Thank you!