### PR TITLE
warn if ISC is already enabled

### DIFF
--- a/isc.php
+++ b/isc.php
@@ -6,7 +6,6 @@
  * Description: Image Source Control saves the source of an image, lists them and warns if it is missing.
  * Author: Thomas Maier
  * Author URI: https://imagesourcecontrol.com/
- * Text Domain: image-source-control-isc
  * License: GPL v3
  *
  * Image Source Control Plugin for WordPress
@@ -27,7 +26,7 @@
  */
 
 if ( class_exists( 'ISC_Class', false ) ) {
-	exit;
+	die( 'You can only activate Image Source Control once. Please disable the other version first.' );
 }
 
 define( 'ISCVERSION', '2.4.0' );

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,10 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 == Changelog ==
 
+= untagged =
+
+- Improvement: Warn if one tries to enable multiple versions of ISC at the same time
+
 = 2.4.0 =
 
 - Feature: ISC Storage to prevent SQL queries in the frontend, [#131](https://github.com/image-source-control/image-source-control/issues/131), [#132](https://github.com/image-source-control/image-source-control/issues/133),


### PR DESCRIPTION
Show a hint about ISC already being enabled when one tries to enable another instance of the plugin.