### PR TITLE
Rename list methods

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -219,12 +219,12 @@ class ISC_Admin extends ISC_Class {
 
 		// Position: How and where to display image sources
 		add_settings_section( 'isc_settings_section_source_type', __( 'Position of the image sources', 'image-source-control-isc' ), array( $this, 'render_section_position' ), 'isc_settings_page' );
-		add_settings_field( 'source_type_list', '1. ' . __( 'Image source list', 'image-source-control-isc' ), array( $this, 'renderfield_source_type_list' ), 'isc_settings_page', 'isc_settings_section_source_type' );
+		add_settings_field( 'source_type_list', '1. ' . __( 'Per-page list', 'image-source-control-isc' ), array( $this, 'renderfield_source_type_list' ), 'isc_settings_page', 'isc_settings_section_source_type' );
 		add_settings_field( 'source_type_overlay', '2. ' . __( 'Overlay', 'image-source-control-isc' ), array( $this, 'renderfield_source_type_overlay' ), 'isc_settings_page', 'isc_settings_section_source_type' );
-		add_settings_field( 'full_list_type', '3. ' . __( 'List with all sources', 'image-source-control-isc' ), array( $this, 'renderfield_source_type_complete_list' ), 'isc_settings_page', 'isc_settings_section_source_type' );
+		add_settings_field( 'full_list_type', '3. ' . __( 'Global list', 'image-source-control-isc' ), array( $this, 'renderfield_source_type_complete_list' ), 'isc_settings_page', 'isc_settings_section_source_type' );
 
 		// settings for sources list below content
-		add_settings_section( 'isc_settings_section_list_below_content', '1. ' . __( 'Image source list', 'image-source-control-isc' ), '__return_false', 'isc_settings_page' );
+		add_settings_section( 'isc_settings_section_list_below_content', '1. ' . __( 'Per-page list', 'image-source-control-isc' ), '__return_false', 'isc_settings_page' );
 		add_settings_field( 'image_list_headline', __( 'Headline', 'image-source-control-isc' ), array( $this, 'renderfield_list_headline' ), 'isc_settings_page', 'isc_settings_section_list_below_content' );
 		add_settings_field( 'below_content_included_images', __( 'Included images', 'image-source-control-isc' ), array( $this, 'renderfield_below_content_included_images' ), 'isc_settings_page', 'isc_settings_section_list_below_content' );
 
@@ -235,8 +235,8 @@ class ISC_Admin extends ISC_Class {
 		add_settings_field( 'overlay_position', __( 'Overlay position', 'image-source-control-isc' ), array( $this, 'renderfield_overlay_position' ), 'isc_settings_page', 'isc_settings_section_overlay' );
 		add_settings_field( 'overlay_included_images', __( 'Included images', 'image-source-control-isc' ), array( $this, 'renderfield_overlay_included_images' ), 'isc_settings_page', 'isc_settings_section_overlay' );
 
-		// full image sources list group
-		add_settings_section( 'isc_settings_section_complete_list', '3. ' . __( 'List with all sources', 'image-source-control-isc' ), '__return_false', 'isc_settings_page' );
+		// Global list group
+		add_settings_section( 'isc_settings_section_complete_list', '3. ' . __( 'Global list', 'image-source-control-isc' ), '__return_false', 'isc_settings_page' );
 		add_settings_field( 'thumbnail_in_list', __( 'Use thumbnails', 'image-source-control-isc' ), array( $this, 'renderfield_thumbnail_in_list' ), 'isc_settings_page', 'isc_settings_section_complete_list' );
 		add_settings_field( 'thumbnail_width', __( 'Thumbnails max-width', 'image-source-control-isc' ), array( $this, 'renderfield_thumbnail_width' ), 'isc_settings_page', 'isc_settings_section_complete_list' );
 		add_settings_field( 'thumbnail_height', __( 'Thumbnails max-height', 'image-source-control-isc' ), array( $this, 'renderfield_thumbnail_height' ), 'isc_settings_page', 'isc_settings_section_complete_list' );
@@ -361,7 +361,7 @@ class ISC_Admin extends ISC_Class {
 	}
 
 	/**
-	 * Position: option to enable Image source lists
+	 * Position: option to enable the Per-page list
 	 */
 	public function renderfield_source_type_list() {
 		$options = $this->get_isc_options();
@@ -437,7 +437,7 @@ class ISC_Admin extends ISC_Class {
 	}
 
 	/**
-	 * Render option to display thumbnails in the full image source list
+	 * Render option to display thumbnails in the Global list
 	 */
 	public function renderfield_thumbnail_in_list() {
 		$options = $this->get_isc_options();
@@ -465,7 +465,7 @@ class ISC_Admin extends ISC_Class {
 	}
 
 	/**
-	 * Render option to define the width of the thumbnails displayed in the full image source list.
+	 * Render option to define the width of the thumbnails displayed in the Global list.
 	 */
 	public function renderfield_thumbnail_width() {
 		$options = $this->get_isc_options();
@@ -473,7 +473,7 @@ class ISC_Admin extends ISC_Class {
 	}
 
 	/**
-	 * Render option to define the height of the thumbnails displayed in the full image source list.
+	 * Render option to define the height of the thumbnails displayed in the Global list.
 	 */
 	public function renderfield_thumbnail_height() {
 		$options = $this->get_isc_options();

--- a/admin/templates/settings/source-type-list.php
+++ b/admin/templates/settings/source-type-list.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Render settings to enable Image source lists in the content
+ * Render settings to enable Per-page lists in the content
  *
  * @var array $options ISC options.
  */

--- a/public/public.php
+++ b/public/public.php
@@ -356,7 +356,7 @@ class ISC_Public extends ISC_Class {
 	}
 
 	/**
-	 * Add the image source list ot the content if the option is enabled
+	 * Add the Per-page list if the option is enabled
 	 *
 	 * @param string $content post content.
 	 * @return string $content
@@ -364,7 +364,7 @@ class ISC_Public extends ISC_Class {
 	public function add_source_list_to_content( $content ) {
 
 		/**
-		 * Display the image source list below the content
+		 * Display the Per-page list
 		 * on single pages if the following option is enabled: How to display source in Frontend > list below content
 		 * on archive pages and home pages with posts if the following option is enabled: Archive Pages > Display sources list below full posts
 		 */

--- a/readme.txt
+++ b/readme.txt
@@ -30,7 +30,7 @@ Choose between different credit displays:
 
 * display credits for images in the content, galleries, shortcodes, and featured images
 * define the layout and position of the image source
-* attach the image source list below the content automatically or using a shortcode or PHP function
+* attach the Per-page list automatically or using a shortcode or PHP function
 * display image sources on archive pages
 * block editor: detects image sources for the image, cover image, and gallery blocks
 * link to the copyright holder and include a link to the image license
@@ -58,7 +58,7 @@ You can choose to display image sources automatically below the post content or 
 
 **Manually included image sources on pages/posts**
 
-You can add the image source list manually to pages or posts via the shortcode `[isc_list]` in your content editor or a text widget.
+You can add the Per-page list manually to pages or posts via the shortcode `[isc_list]` in your content editor or a text widget.
 
 Use `[isc_list id="123]` to show the list of any post or page.
 


### PR DESCRIPTION
"Image source list" is now called "Per-post list" while "List with all sources" or "Full list" is called "Global list".

Fixes #146