### PR TITLE
Localize links to our homepage based on the admin language

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -824,11 +824,46 @@ class ISC_Admin extends ISC_Class {
 	}
 
 	/**
+	 * Get URL to the ISC website by site language
+	 *
+	 * @return string website URL
+	 */
+	public static function get_isc_website_url( ) {
+		// check if the locale starts with "de_"
+		if ( strpos( determine_locale(), 'de_' ) === 0 ) {
+			return 'https://imagesourcecontrol.de/';
+		} else {
+			return 'https://imagesourcecontrol.com/';
+		}
+	}
+
+	/**
 	 * Get link to ISC Pro
 	 *
-	 * @param string $utm_campaign Position of the upsell for the campaign link
+	 * @param string $utm_campaign Position of the link for the campaign link
 	 */
 	public static function get_pro_link( $utm_campaign = 'upsell-link' ) {
-		return '<a href="https://imagesourcecontrol.com/pricing/?utm_source=isc-plugin&utm_medium=link&utm_campaign=' . $utm_campaign . '" class="isc-get-pro" target="_blank">' . esc_html__( 'Get ISC Pro', 'image-source-control-isc' ) . '</a>';
+		// check if the locale starts with "de_"
+		if ( strpos( determine_locale(), 'de_' ) === 0 ) {
+			$base_url = 'https://imagesourcecontrol.de/preise/';
+		} else {
+			$base_url = 'https://imagesourcecontrol.com/pricing/';
+		}
+		return '<a href="' . $base_url . '?utm_source=isc-plugin&utm_medium=link&utm_campaign=' . $utm_campaign . '" class="isc-get-pro" target="_blank">' . esc_html__( 'Get ISC Pro', 'image-source-control-isc' ) . '</a>';
+	}
+
+	/**
+	 * Get link to the ISC manual
+	 *
+	 * @param string $utm_campaign Position of the link for the campaign link
+	 */
+	public static function get_manual_url( $utm_campaign = 'manual' ) {
+		// check if the locale starts with "de_"
+		if ( strpos( determine_locale(), 'de_' ) === 0 ) {
+			$base_url = 'https://imagesourcecontrol.de/anleitung/';
+		} else {
+			$base_url = 'https://imagesourcecontrol.com/manual/';
+		}
+		return $base_url . '?utm_source=isc-plugin&utm_medium=link&utm_campaign=' . $utm_campaign;
 	}
 }

--- a/admin/assets/css/isc.css
+++ b/admin/assets/css/isc.css
@@ -61,7 +61,7 @@
     text-decoration: none;
 }
 
-#isc-header-links a.isc-header-links-pro {
+#isc-header-links a.isc-get-pro {
     background-color: #F70;
     font-weight: bold;
 }

--- a/admin/templates/header.php
+++ b/admin/templates/header.php
@@ -12,9 +12,9 @@
 		<h1><?php echo esc_html( $title ); ?></h1>
 	</div>
 	<div id="isc-header-links">
-		<?php if ( ! class_exists( 'ISC_Pro_Admin', false ) ) : ?>
-			<a class="isc-header-links-pro" href="https://imagesourcecontrol.com/pricing/?utm_source=isc-plugin&utm_medium=link&utm_campaign=header-pro" target="_blank"><?php esc_html_e( 'Get ISC Pro', 'image-source-control-isc' ); ?></a>
-		<?php endif; ?>
+		<?php if ( ! class_exists( 'ISC_Pro_Admin', false ) ) :
+			echo ISC_Admin::get_pro_link( 'header-pro' );
+		endif; ?>
 		<?php switch ( $screen_id ) :
 			case 'settings_page_isc-settings' : ?>
 				<a href="<?php echo esc_url( admin_url( 'upload.php?page=isc-sources' ) ); ?>"><?php esc_html_e( 'Tools', 'image-source-control-isc' ); ?></a>
@@ -23,7 +23,7 @@
 				<a href="<?php echo esc_url( admin_url( 'options-general.php?page=isc-settings' ) ); ?>"><?php esc_html_e( 'Settings', 'image-source-control-isc' ); ?></a>
 		<?php break; ?>
 		<?php endswitch; ?>
-		<a href="https://imagesourcecontrol.com/manual/?utm_source=isc-plugin&utm_medium=link&utm_campaign=header-manual" target="_blank"><?php esc_html_e( 'Manual', 'image-source-control-isc' ); ?></a>
+		<a href="<?php echo ISC_Admin::get_manual_url( 'header-manual' ); ?>" target="_blank"><?php esc_html_e( 'Manual', 'image-source-control-isc' ); ?></a>
 	</div>
 </div>
 <div class="wrap">

--- a/admin/templates/settings/source-type-list.php
+++ b/admin/templates/settings/source-type-list.php
@@ -33,7 +33,7 @@
 			)
 		);
 		?>
-		 <a href="https://imagesourcecontrol.com/manual/" target="_blank"><?php esc_html_e( 'Manual', 'image-source-control-isc' ); ?></a>
+		 <a href="<?php echo ISC_Admin::get_manual_url( 'settings-per-page-list-position' ); ?>" target="_blank"><?php esc_html_e( 'Manual', 'image-source-control-isc' ); ?></a>
 	</p>
 	<h4><?php esc_html_e( 'Archive pages', 'image-source-control-isc' ); ?></h4>
 	<p class="description"><?php esc_html_e( 'The following options try to place image sources within post content on post list pages like your home page or category archives.', 'image-source-control-isc' ); ?></p>

--- a/admin/templates/sources.php
+++ b/admin/templates/sources.php
@@ -122,6 +122,6 @@ endif;
 <button id="isc-clear-storage" class="button button-secondary"><?php esc_html_e( 'clear storage', 'image-source-control-isc' ); ?></button>
 <p class="description"><?php esc_html_e( 'ISC keeps an internal index of image URLs and IDs from the media library to limit the number of database requests in the frontend.', 'image-source-control-isc' ); ?>
 	<br/><?php esc_html_e( 'Click the button above to clear that index.', 'image-source-control-isc' ); ?>
-	<a href="https://imagesourcecontrol.com/technical-information/#Image_URL_Storage" target="_blank" rel="noopener"><?php esc_html_e( 'Manual', 'image-source-control-isc' ); ?></a>
+	<a href="<?php echo ISC_Admin::get_manual_url( 'tools-clear-index' ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'Manual', 'image-source-control-isc' ); ?></a>
 </p>
 <div id="isc-clear-storage-feedback"></div>


### PR DESCRIPTION
With our German website being on a different TLD, we are now pointing the links in the backend towards the right version based on the backend language.