### PR TITLE
Improve missing sources warnings

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -90,15 +90,15 @@ class ISC_Admin extends ISC_Class {
 				return;
 		};
 
-		$show_warning = get_transient( 'isc-show-missing-sources-warning' );
+		$missing_sources = (int) get_transient( 'isc-show-missing-sources-warning' );
 
 		// check for missing sources if the transient is empty and store that value
-		if ( ! $show_warning ) {
-			$show_warning = ISC_Model::update_missing_sources_transient();
+		if ( ! $missing_sources ) {
+			$missing_sources = ISC_Model::update_missing_sources_transient();
 		}
 
 		// attachments without sources
-		if ( $show_warning && 'no' !== $show_warning ) {
+		if ( $missing_sources ) {
 			require_once ISCPATH . '/admin/templates/notice-missing.php';
 		}
 	}
@@ -606,65 +606,6 @@ class ISC_Admin extends ISC_Class {
 		$checked = ! empty( $options['remove_on_uninstall'] );
 		require_once ISCPATH . '/admin/templates/settings/remove-on-uninstall.php';
 	}
-
-	/**
-	 * Get all attachments with empty sources options.
-	 *
-	 * @return array with attachments.
-	 */
-	public static function get_attachments_with_empty_sources() {
-		$args = array(
-			'post_type'   => 'attachment',
-			'numberposts' => -1,
-			'post_status' => null,
-			'post_parent' => null,
-			'meta_query'  => array(
-				// image source is empty
-				array(
-					'key'     => 'isc_image_source',
-					'value'   => '',
-					'compare' => '=',
-				),
-				// and does not belong to an author
-				array(
-					'key'     => 'isc_image_source_own',
-					'value'   => '1',
-					'compare' => '!=',
-				),
-			),
-		);
-
-		// is per function definition always returning an array, even if empty.
-		return get_posts( $args );
-	}
-
-	/**
-	 * Get all attachments that are not used
-	 * read: they don’t have the proper meta values set up, yet.
-	 *
-	 * @since 1.6
-	 * @return array with attachments.
-	 */
-	public static function get_unused_attachments() {
-		$args = array(
-			'post_type'   => 'attachment',
-			'numberposts' => -1,
-			'post_status' => null,
-			'post_parent' => null,
-			'meta_query'  => array(
-				// image source is empty
-				array(
-					'key'     => 'isc_image_source',
-					'value'   => 'any', /* any string; needed prior to WP 3.9 */
-					'compare' => 'NOT EXISTS',
-				),
-			),
-		);
-
-		// is per function definition always returning an array, even if empty.
-		return get_posts( $args );
-	}
-
 
 	/**
 	 * List image post relations (called with ajax)

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -163,8 +163,10 @@ class ISC_Admin extends ISC_Class {
 				.row-actions .isc-get-pro { font-weight: bold; color: #F70; }
 			</style><?php
 		}
+		// add to any backend pages
 		?><style>
 			.compat-attachment-fields .isc-get-pro{ font-weight: bold; color: #F70; }
+			div.error.isc-notice { border-left-color: #F70; }
 		</style>
 		<?php
 		// add nonce to all pages

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -86,7 +86,11 @@ class ISC_Admin extends ISC_Class {
 
 		// only check, if check-option was enabled
 		$options = $this->get_isc_options();
-		if ( empty( $options['warning_onesource_missing'] ) ) {
+		// skip the warning on the image sources screen since the list shows up there
+		$screen = get_current_screen();
+		if ( empty( $options['warning_onesource_missing'] )
+			 || empty( $screen->id )
+			 || $screen->id === 'media_page_isc-sources' ) {
 				return;
 		};
 

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -22,7 +22,7 @@ class ISC_Admin extends ISC_Class {
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 
 		// settings page
-		add_action( 'admin_menu', array( $this, 'create_menu' ) );
+		add_action( 'admin_menu', array( $this, 'add_menu_items' ) );
 		add_action( 'admin_init', array( $this, 'settings_init' ) );
 
 		// scripts and styles
@@ -241,17 +241,33 @@ class ISC_Admin extends ISC_Class {
 	}
 
 	/**
-	 * Create the menu pages for isc
-	 *
-	 * @since 1.0
+	 * Create the menu pages for ISC with access for editors and higher roles
 	 */
-	public function create_menu() {
-		global $isc_page;
-		global $isc_setting;
+	public function add_menu_items() {
 
-		// These pages should be available only for editors and higher
-		$isc_page    = add_submenu_page( 'upload.php', esc_html__( 'Image Source Control', 'image-source-control-isc' ), __( 'Image Sources', 'image-source-control-isc' ), 'edit_others_posts', 'isc-sources', array( $this, 'render_sources_page' ) );
-		$isc_setting = add_options_page( __( 'Image Source Control Settings', 'image-source-control-isc' ), __( 'Image Sources', 'image-source-control-isc' ), 'edit_others_posts', 'isc-settings', array( $this, 'render_isc_settings_page' ) );
+		$options = $this->get_isc_options();
+		if ( empty( $options['warning_onesource_missing'] ) ) {
+			$notice_alert = '';
+		} else {
+			$missing_images = get_transient( 'isc-show-missing-sources-warning' );
+			$notice_alert = '&nbsp;<span class="update-plugins count-' . $missing_images . '"><span class="update-count">' . $missing_images . '</span></span>';
+		}
+
+		add_submenu_page(
+			'upload.php',
+			esc_html__( 'Image Source Control', 'image-source-control-isc' ),
+			__( 'Image Sources', 'image-source-control-isc' ) . $notice_alert,
+			'edit_others_posts',
+			'isc-sources',
+			array( $this, 'render_sources_page' ) );
+
+		add_options_page(
+			__( 'Image Source Control Settings', 'image-source-control-isc' ),
+			__( 'Image Sources', 'image-source-control-isc' ),
+			'edit_others_posts',
+			'isc-settings',
+			array( $this, 'render_isc_settings_page' )
+		);
 	}
 
 	/**

--- a/admin/templates/notice-missing.php
+++ b/admin/templates/notice-missing.php
@@ -1,17 +1,27 @@
+<?php
+/**
+ * Render warning about number of missing sources.
+ *
+ * @var integer $missing_sources number of missing sources.
+ */
+?>
 <div class="wrap">
 	<div class="error"><p>
 		<?php
+		printf( _n( '%s image has no credits.', '%s images have no credits.', $missing_sources, 'image-source-control-isc' ), $missing_sources );
+		echo ' ';
 		printf(
 			wp_kses(
-			// translators: %s is a URL
-				__( 'One or more attachments still have no source. See the <a href="%s">missing sources</a> list', 'image-source-control-isc' ),
+			// translators: %1$s is an opening link tag, %2$s is a closing tag.
+				__( 'See the %1$smissing sources%2$s list', 'image-source-control-isc' ),
 				array(
 					'a' => array(
 						'href' => array(),
 					),
 				)
 			),
-			esc_url( admin_url( 'upload.php?page=isc-sources' ) )
+			'<a href="' . esc_url( admin_url( 'upload.php?page=isc-sources' ) ) . '">',
+			'</a>'
 		);
 		?>
 	</p></div>

--- a/admin/templates/notice-missing.php
+++ b/admin/templates/notice-missing.php
@@ -6,7 +6,7 @@
  */
 ?>
 <div class="wrap">
-	<div class="error"><p>
+	<div class="error isc-notice"><p>
 		<?php
 		printf( _n( '%s image has no credits.', '%s images have no credits.', $missing_sources, 'image-source-control-isc' ), $missing_sources );
 		echo ' ';

--- a/admin/templates/notice-missing.php
+++ b/admin/templates/notice-missing.php
@@ -13,7 +13,7 @@
 		printf(
 			wp_kses(
 			// translators: %1$s is an opening link tag, %2$s is a closing tag.
-				__( 'See the %1$smissing sources%2$s list', 'image-source-control-isc' ),
+				__( 'See the %1$smissing sources%2$s list.', 'image-source-control-isc' ),
 				array(
 					'a' => array(
 						'href' => array(),

--- a/admin/templates/sources.php
+++ b/admin/templates/sources.php
@@ -6,7 +6,7 @@
  */
 ?>
 <?php
-$attachments = ISC_Admin::get_attachments_with_empty_sources();
+$attachments = ISC_Model::get_attachments_with_empty_sources();
 if ( ! empty( $attachments ) ) :
 	?>
 	<h2><?php esc_html_e( 'Images with empty sources', 'image-source-control-isc' ); ?></h2>
@@ -44,7 +44,7 @@ else :
 	<?php
 endif;
 
-$attachments = ISC_Admin::get_unused_attachments();
+$attachments = ISC_Model::get_unused_attachments();
 if ( ! empty( $attachments ) ) :
 	?>
 	<h2><?php esc_html_e( 'Images with unknown position', 'image-source-control-isc' ); ?></h2>

--- a/includes/model.php
+++ b/includes/model.php
@@ -422,7 +422,7 @@ class ISC_Model {
 	}
 
 	/**
-	 * Update the transient we set for missing sources to not check them for another hour
+	 * Update the transient we set for missing sources to not check them for another day
 	 * running each time we are writing the `isc_image_source` post meta key
 	 *
 	 * @return int number of missing sources.


### PR DESCRIPTION
Improved the missing sources warning to include the number of missing sources.
Hide the warning on the actual ISC page where it can be fixed by users.
Show an icon with the number of missing sources next to the Image Sources menu item.
Use the ISC brand color to highlight the missing sources notice.

![Bildschirmfoto 2022-03-22 um 18 54 53](https://user-images.githubusercontent.com/2728720/159544767-b266b081-3731-465f-bfb6-d2de70cbf09a.png)

Fixes #151
Fixes #152 