### PR TITLE
Implement alternative tallying functionality

### DIFF
--- a/includes/model.php
+++ b/includes/model.php
@@ -350,15 +350,17 @@ class ISC_Model {
 	 * Checks if there are image with missing sources
 	 * this includes attachments that were not indexed yet (don’t have the appropriate meta values)
 	 *
+	 * Functions are called with parameter $returnCount set to TRUE to reduce data returned by the query to post ID fields
+	 *
 	 * @return int number of images with missing sources
 	 */
 	public static function count_missing_sources() {
 
 		// get known and used attachments without sources
-		$count = count( self::get_attachments_with_empty_sources() );
+		$count = count( self::get_attachments_with_empty_sources(TRUE) );
 
 		// look for unindexed attachments
-		$count += count( self::get_unused_attachments() );
+		$count += count( self::get_unused_attachments(TRUE) );
 
 		return $count;
 	}
@@ -369,7 +371,7 @@ class ISC_Model {
 	 *
 	 * @return array with attachments.
 	 */
-	public static function get_attachments_with_empty_sources() {
+	public static function get_attachments_with_empty_sources($returnCount = FALSE) {
 		$args = array(
 			'post_type'   => 'attachment',
 			'numberposts' => -1,
@@ -390,6 +392,12 @@ class ISC_Model {
 				),
 			),
 		);
+		/**
+		 * query only ID fields in order to reduce resource consumption for tallying up missing sources and unused attachments
+		 */
+		if ( $returnCount === TRUE ) {
+			$args['fields'] = 'ids';
+		}
 
 		return get_posts( $args );
 	}
@@ -401,7 +409,7 @@ class ISC_Model {
 	 * @since 1.6
 	 * @return array with attachments.
 	 */
-	public static function get_unused_attachments() {
+	public static function get_unused_attachments($returnCount = FALSE) {
 		$args = array(
 			'post_type'   => 'attachment',
 			'numberposts' => -1,
@@ -416,6 +424,12 @@ class ISC_Model {
 				),
 			),
 		);
+		/**
+		 * query only ID fields in order to reduce resource consumption for tallying up missing sources and unused attachments
+		 */
+		if ( $returnCount === TRUE ) {
+			$args['fields'] = 'ids';
+		}
 
 		// is per function definition always returning an array, even if empty.
 		return get_posts( $args );


### PR DESCRIPTION
See issue #160. Usage of “wpdb” class and querying “SELECT count()” would have been even better, but I don’t feel comfortable causing our code to be prone to possible SQL injection.

Listing of missing/unused sources (sources.php) should not be affected since the functions there are called without parameter, leading to it defaulting to FALSE.