### PR TITLE
change source label for excerpts

### DIFF
--- a/public/public.php
+++ b/public/public.php
@@ -394,11 +394,7 @@ class ISC_Public extends ISC_Class {
 			return $excerpt;
 		}
 
-		$source_string = $this->get_thumbnail_source_string( $post->ID );
-
-		$excerpt = $excerpt . $source_string;
-
-		return $excerpt;
+		return $excerpt . $this->get_thumbnail_source_string( $post->ID );
 	}
 
 	/**
@@ -891,8 +887,6 @@ class ISC_Public extends ISC_Class {
 			return '';
 		}
 
-		$options = $this->get_isc_options();
-
 		if ( has_post_thumbnail( $post_id ) ) {
 			$id    = get_post_thumbnail_id( $post_id );
 			$thumb = get_post( $post_id );
@@ -910,7 +904,7 @@ class ISC_Public extends ISC_Class {
 				return '';
 			}
 
-			return '<p class="isc-source-text">' . $options['source_pretext'] . ' ' . $source_string . '</p>';
+			return '<p class="isc-source-text">' . apply_filters( 'isc_featured_image_source_pre_text', _x( 'Featured image: ', 'label of the featured image source, when displayed below post excerpts', 'image-source-control-isc' ) ) . ' ' . $source_string . '</p>';
 		}
 
 		return '';

--- a/readme.txt
+++ b/readme.txt
@@ -118,6 +118,10 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 == Changelog ==
 
+= untagged =
+
+- Improvement: when the source of the featured image is displayed below post excerpts, it does no longer use the pre-text defined in the Overlay options. It now says "Featured image" by default and can be changed using the `isc_featured_image_source_pre_text` filter
+
 = 2.6.0 =
 
 - Improvement: add FAL and GFDL to available licenses (clear the option to reset the list)


### PR DESCRIPTION
Users can enable the source of the featured image to show in post excerpts. This used the pre-text defined in the Overlay section. This could cause confusion if it says "source" because it could be interpreted as if this is the source of the text, not only the image.

This pull request changes the default pre-text for featured image sources below excerpts into "Featured image" and adds the `isc_featured_image_source_pre_text` filter to allow users to change it.

Fixes #157

Example on using the filter:

```
add_filter( 'isc_featured_image_source_pre_text', function(){
	return 'Featured image author: ';
});
```