### PR TITLE
165 close warning

### DIFF
--- a/admin/templates/notice-missing.php
+++ b/admin/templates/notice-missing.php
@@ -3,6 +3,7 @@
  * Render warning about number of missing sources.
  *
  * @var integer $missing_sources number of missing sources.
+ * @var WP_Screen $screen current screen.
  */
 ?>
 <div class="wrap">
@@ -23,6 +24,23 @@
 			'<a href="' . esc_url( admin_url( 'upload.php?page=isc-sources' ) ) . '">',
 			'</a>'
 		);
+		// show a link to the settings page
+		if ( $screen->id !== 'settings_page_isc-settings' ) {
+			echo ' ';
+			printf(
+				wp_kses(
+				// translators: %1$s is an opening link tag, %2$s is a closing tag.
+					__( 'You can %1$sdisable%2$s this warning in the settings.', 'image-source-control-isc' ),
+					array(
+						'a' => array(
+							'href' => array(),
+						),
+					)
+				),
+				'<a href="' . esc_url( admin_url( 'options-general.php?page=isc-settings#isc_settings_section_misc' ) ) . '">',
+				'</a>'
+			);
+		}
 		?>
 	</p></div>
 </div>

--- a/readme.txt
+++ b/readme.txt
@@ -126,6 +126,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 - Improvement: set color for source link in overlay to be better visible by default
 - Improvement: prevent line breaks for source links in overlays for the Featured Image block since WordPress 6.0
 - Improvement: place overlay correctly on the Cover block
+- Improvement: show link to disable the warning about missing images
 - Fix: plugin options could miss default values on new installations
 
 = 2.6.0 =


### PR DESCRIPTION
The Missing Sources warning now contains a link to the ISC settings which allows users to disable the warning.
The link does not show when the user is already on the settings page.

Fixes #165