### PR TITLE
Fix: use correct endpoints on plain permalinks

### DIFF
--- a/includes/gutenberg/gutenberg.php
+++ b/includes/gutenberg/gutenberg.php
@@ -124,7 +124,11 @@ class Isc_Gutenberg {
 				'option'   => $plugin_options,
 				'postmeta' => new stdClass(),
 				'nonce'    => wp_create_nonce( 'isc-gutenberg-nonce' ),
-				'route' => site_url( '/wp-json/image-source-control/v1/load-fields/' ),
+				'route'      => ( get_option( 'permalink_structure', '' ) === '' )
+					?
+					site_url( 'index.php?rest_route=' . urlencode( '/image-source-control/v1/load-fields/' ) )
+					:
+					site_url( '/wp-json/image-source-control/v1/load-fields/' ),
 				'rest_nonce' => wp_create_nonce( 'wp_rest' ),
 			);
 

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 = untagged =
 
+- Improvement: load ISC fields only for images present in the currently edited page
 - Improvement: when the source of the featured image is displayed below post excerpts, it does no longer use the pre-text defined in the Overlay options. It now says "Featured image" by default and can be changed using the `isc_featured_image_source_pre_text` filter
 
 = 2.6.0 =


### PR DESCRIPTION
Loading ISC fields via REST API was not working on installation using the default permalink structure.

fix #171