### PR TITLE
Added ISC fields on Media & Text block

### DIFF
--- a/includes/gutenberg/isc-image-block.js
+++ b/includes/gutenberg/isc-image-block.js
@@ -8,7 +8,7 @@
 	var Fragment = wp.element.Fragment;
 	var el = wp.element.createElement;
 
-	var enableSourceControlOnBlocks = ['core/image', 'core/cover'];
+	var enableSourceControlOnBlocks = ['core/image', 'core/cover', 'core/media-text'];
 
 	var licenceList = [''];
 
@@ -184,23 +184,25 @@
 					return el(BlockEdit, props);
 				}
 
+				var id = props.attributes.id || props.attributes.mediaId;
+
 				// If an image has not been selected yet, do not display the source control fields.
-				if (isNaN(props.attributes.id)) {
+				if (isNaN(id)) {
 					return el(BlockEdit, props);
 				}
 
-				if ('undefined' != typeof iscData.postmeta[props.attributes.id]) {
+				if ('undefined' != typeof iscData.postmeta[id]) {
 					props.setAttributes({
-						'isc_image_source': iscData.postmeta[props.attributes.id]['isc_image_source'],
-						'isc_image_source_url': iscData.postmeta[props.attributes.id]['isc_image_source_url'],
-						'isc_image_source_own': iscData.postmeta[props.attributes.id]['isc_image_source_own'],
-						'isc_image_licence': iscData.postmeta[props.attributes.id]['isc_image_licence'],
+						'isc_image_source': iscData.postmeta[id]['isc_image_source'],
+						'isc_image_source_url': iscData.postmeta[id]['isc_image_source_url'],
+						'isc_image_source_own': iscData.postmeta[id]['isc_image_source_own'],
+						'isc_image_licence': iscData.postmeta[id]['isc_image_licence'],
 					});
 				} else {
 					// ISC fields not yet queried. Queue it.
 					props.setAttributes(emptyMeta);
-					if ( typeof currentMetaLoading[props.attributes.id] === 'undefined' ) {
-						loadImageMeta(props.attributes.id, props.setAttributes);
+					if ( typeof currentMetaLoading[id] === 'undefined' ) {
+						loadImageMeta(id, props.setAttributes);
 					}
 				}
 
@@ -209,8 +211,6 @@
 				var isc_image_source_url = props.attributes.isc_image_source_url;
 				var isc_image_licence = props.attributes.isc_image_licence;
 				var disabled = props.attributes.saving_meta;
-
-				var id = props.attributes.id;
 
 				var panelFields = [el(wp.components.TextControl, {
 						label: __('Image Source', 'image-source-control-isc'),

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 = untagged =
 
+- Improvement: added ISC fields on Media & Text block
 - Improvement: load ISC fields only for images present in the currently edited page
 - Improvement: when the source of the featured image is displayed below post excerpts, it does no longer use the pre-text defined in the Overlay options. It now says "Featured image" by default and can be changed using the `isc_featured_image_source_pre_text` filter
 


### PR DESCRIPTION
ISC fields doesn't appear on the recent Media & Text block yet.

fixes #169