### PR TITLE
load plugin options with defaults

### DIFF
--- a/isc.class.php
+++ b/isc.class.php
@@ -101,7 +101,7 @@ class ISC_Class {
 		 */
 		public function __construct() {
 			// load all plugin options
-			$this->options  = get_option( 'isc_options' );
+			$this->options  = $this->get_isc_options();
 			self::$instance = $this;
 			$this->model    = new ISC_Model();
 

--- a/public/public.php
+++ b/public/public.php
@@ -494,7 +494,7 @@ class ISC_Public extends ISC_Class {
 		}
 
 		$options  = $this->get_isc_options();
-		$headline = $this->options['image_list_headline'];
+		$headline = $options['image_list_headline'];
 
 		ob_start();
 

--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 - Improvement: load ISC fields only for images present in the currently edited page
 - Improvement: when the source of the featured image is displayed below post excerpts, it does no longer use the pre-text defined in the Overlay options. It now says "Featured image" by default and can be changed using the `isc_featured_image_source_pre_text` filter
+- Fix: plugin options could miss default values on new installations
 
 = 2.6.0 =
 


### PR DESCRIPTION
ISC_Class could load empty plugin options and skip default values. This PR fixes that.

Fixes #175