### PR TITLE
Various CSS styling fixes

### DIFF
--- a/public/public.php
+++ b/public/public.php
@@ -102,6 +102,10 @@ class ISC_Public extends ISC_Class {
 			</script>
 			<style>
 				.isc-source { position: relative; display: inline-block; }
+				<?php
+				// The 2022 theme adds display:block to the featured image block, which creates additional line breaks. The following line fixes that.
+				?>
+				.isc-source-text a { display: inline-block; }
 			</style>
 			<?php
 	}

--- a/public/public.php
+++ b/public/public.php
@@ -102,6 +102,7 @@ class ISC_Public extends ISC_Class {
 			</script>
 			<style>
 				.isc-source { position: relative; display: inline-block; }
+                .wp-block-cover .isc-source { position: static; }
 				<?php
 				// The 2022 theme adds display:block to the featured image block, which creates additional line breaks. The following line fixes that.
 				?>

--- a/public/public.php
+++ b/public/public.php
@@ -104,9 +104,9 @@ class ISC_Public extends ISC_Class {
 				.isc-source { position: relative; display: inline-block; }
                 .wp-block-cover .isc-source { position: static; }
 				<?php
-				// The 2022 theme adds display:block to the featured image block, which creates additional line breaks. `display: inline-block` fixes that.
+				// The 2022 theme adds display:block to the featured image block, which creates additional line breaks. `display: inline` fixes that.
 				?>
-				.isc-source-text a { display: inline-block; color: #fff; }
+				.isc-source-text a { display: inline; color: #fff; }
 			</style>
 			<?php
 	}

--- a/public/public.php
+++ b/public/public.php
@@ -104,9 +104,9 @@ class ISC_Public extends ISC_Class {
 				.isc-source { position: relative; display: inline-block; }
                 .wp-block-cover .isc-source { position: static; }
 				<?php
-				// The 2022 theme adds display:block to the featured image block, which creates additional line breaks. The following line fixes that.
+				// The 2022 theme adds display:block to the featured image block, which creates additional line breaks. `display: inline-block` fixes that.
 				?>
-				.isc-source-text a { display: inline-block; }
+				.isc-source-text a { display: inline-block; color: #fff; }
 			</style>
 			<?php
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -124,11 +124,8 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 - Improvement: when the source of the featured image is displayed below post excerpts, it does no longer use the pre-text defined in the Overlay options. It now says "Featured image" by default and can be changed using the `isc_featured_image_source_pre_text` filter
 - Improvement: set color for source link in overlay to be better visible by default
 - Improvement: prevent line breaks for source links in overlays for the Featured Image block since WordPress 6.0
-<<<<<<< HEAD
-- Fix: plugin options could miss default values on new installations
-=======
 - Improvement: place overlay correctly on the Cover block
->>>>>>> cff8055 (fix overlay on cover block)
+- Fix: plugin options could miss default values on new installations
 
 = 2.6.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 - Improvement: load ISC fields only for images present in the currently edited page
 - Improvement: when the source of the featured image is displayed below post excerpts, it does no longer use the pre-text defined in the Overlay options. It now says "Featured image" by default and can be changed using the `isc_featured_image_source_pre_text` filter
+- Improvement: set color for source link in overlay to be better visible by default
 - Improvement: prevent line breaks for source links in overlays for the Featured Image block since WordPress 6.0
 <<<<<<< HEAD
 - Fix: plugin options could miss default values on new installations

--- a/readme.txt
+++ b/readme.txt
@@ -123,7 +123,11 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 - Improvement: load ISC fields only for images present in the currently edited page
 - Improvement: when the source of the featured image is displayed below post excerpts, it does no longer use the pre-text defined in the Overlay options. It now says "Featured image" by default and can be changed using the `isc_featured_image_source_pre_text` filter
 - Improvement: prevent line breaks for source links in overlays for the Featured Image block since WordPress 6.0
+<<<<<<< HEAD
 - Fix: plugin options could miss default values on new installations
+=======
+- Improvement: place overlay correctly on the Cover block
+>>>>>>> cff8055 (fix overlay on cover block)
 
 = 2.6.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 - Improvement: load ISC fields only for images present in the currently edited page
 - Improvement: when the source of the featured image is displayed below post excerpts, it does no longer use the pre-text defined in the Overlay options. It now says "Featured image" by default and can be changed using the `isc_featured_image_source_pre_text` filter
+- Improvement: prevent line breaks for source links in overlays for the Featured Image block since WordPress 6.0
 - Fix: plugin options could miss default values on new installations
 
 = 2.6.0 =


### PR DESCRIPTION
WordPress 6.0 introduces CSS that causes links in the Featured Image block to have line breaks. This PR overrides this for links added by ISC.

Fixes image-source-control/image-source-control-pro/issues/68

The cover block did not show the image source when the overlay was enabled.

Fixes #176

The links in overlays were often overridden by the theme font color, which are often dark. So it was hard to read on the dark background. This PR sets a static color (white) by default. Users can still override it with custom CSS.

Fixes #178