### PR TITLE
Added ISC fields to post featured image block

### DIFF
--- a/includes/gutenberg/isc-image-block.js
+++ b/includes/gutenberg/isc-image-block.js
@@ -8,7 +8,7 @@
 	var Fragment = wp.element.Fragment;
 	var el = wp.element.createElement;
 
-	var enableSourceControlOnBlocks = ['core/image', 'core/cover', 'core/media-text'];
+	var enableSourceControlOnBlocks = ['core/image', 'core/cover', 'core/media-text', 'core/post-featured-image'];
 
 	var licenceList = [''];
 
@@ -186,8 +186,12 @@
 
 				var id = props.attributes.id || props.attributes.mediaId;
 
+				if ( props.name === 'core/post-featured-image' ) {
+					id = wp.data.select('core/editor').getEditedPostAttribute('featured_media');
+				}
+
 				// If an image has not been selected yet, do not display the source control fields.
-				if (isNaN(id)) {
+				if (isNaN(id) || id === 0) {
 					return el(BlockEdit, props);
 				}
 

--- a/readme.txt
+++ b/readme.txt
@@ -120,7 +120,8 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 = untagged =
 
-- Improvement: added ISC fields on Media & Text block
+- Feature: added ISC fields to Media & Text block
+- Feature: added ISC fields to post featured image block
 - Improvement: load ISC fields only for images present in the currently edited page
 - Improvement: when the source of the featured image is displayed below post excerpts, it does no longer use the pre-text defined in the Overlay options. It now says "Featured image" by default and can be changed using the `isc_featured_image_source_pre_text` filter
 - Improvement: set color for source link in overlay to be better visible by default


### PR DESCRIPTION
Show ISC options for the Featured Image block in WordPress 5.9

Note: as indicated in https://developer.wordpress.org/block-editor/reference-guides/data/data-core-editor/#getcurrentpost the featured image ID is the one known in the last saved state

fixes #137