### PR TITLE
sync overlay margin

### DIFF
--- a/public/assets/js/captions.js
+++ b/public/assets/js/captions.js
@@ -75,41 +75,41 @@ function isc_update_caption_position( el ) {
 	var attmt = parseInt( window.getComputedStyle( att )[ 'margin-top' ].substring( 0, window.getComputedStyle( att )[ 'margin-top' ].indexOf( 'px' ) ) );
 
 	// caption horizontal margin
-	var tml = 5;
+	var tml = 0;
 	// caption vertical margin
-	var tmt = 5;
+	var tmt = 0;
 
 	var pos  = isc_front_data.caption_position;
 	var posl = 0;
 	var post = 0;
 	switch (pos) {
 		case 'top-left':
-			posl = l + attpl + attml + tml;
-			post = t + attpt + attmt + tmt;
+			posl = l + attpl + attml;
+			post = t + attpt + attmt;
 			break;
 		case 'top-center':
 			posl = l + (Math.round( attw / 2 ) - (Math.round( tw / 2 ))) + attpl + attml;
-			post = t + attpt + attmt + tmt;
+			post = t + attpt + attmt;
 			break;
 		case 'top-right':
-			posl = l - attpl + attml - tml + attw - tw;
-			post = t + attpt + attmt + tmt;
+			posl = l - attpl + attml + attw - tw;
+			post = t + attpt + attmt;
 			break;
 		case 'center':
 			posl = l + (Math.round( attw / 2 ) - (Math.round( tw / 2 ))) + attpl + attml;
 			post = t + (Math.round( atth / 2 ) - (Math.round( th / 2 ))) + attpt + attmt;
 			break;
 		case 'bottom-left':
-			posl = l + attpl + attml + tml;
-			post = t - attpt + attmt - tmt - th + atth;
+			posl = l + attpl + attml;
+			post = t - attpt + attmt - th + atth;
 			break;
 		case 'bottom-center':
 			posl = l + (Math.round( attw / 2 ) - (Math.round( tw / 2 ))) + attpl + attml;
-			post = t + attpt + attmt - tmt - th + atth;
+			post = t + attpt + attmt - th + atth;
 			break;
 		case 'bottom-right':
-			posl = l - attpl + attml - tml + attw - tw;
-			post = t + attpt + attmt - tmt - th + atth;
+			posl = l - attpl + attml + attw - tw;
+			post = t + attpt + attmt - th + atth;
 			break;
 	}
 	caption.style.left   = posl + 'px';

--- a/public/public.php
+++ b/public/public.php
@@ -106,6 +106,7 @@ class ISC_Public extends ISC_Class {
 				<?php
 				// The 2022 theme adds display:block to the featured image block, which creates additional line breaks. `display: inline` fixes that.
 				?>
+				.isc-source-text { margin: 5px; }
 				.isc-source-text a { display: inline; color: #fff; }
 			</style>
 			<?php

--- a/readme.txt
+++ b/readme.txt
@@ -125,6 +125,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 - Improvement: set color for source link in overlay to be better visible by default
 - Improvement: prevent line breaks for source links in overlays for the Featured Image block since WordPress 6.0
 - Improvement: place overlay correctly on the Cover block
+- Improvement: use the same margin around the overlay above images, this also fixes multiline overlays jumping when resizing the screen
 - Fix: plugin options could miss default values on new installations
 
 = 2.6.0 =


### PR DESCRIPTION
Multiline overlays were jumping in some cases when the screen was resized. We fixed this and simplified the calculation of the overlay position by using the same margin around the overlay.

Fixes #177