### PR TITLE
Fix: strip all carriage returns in license strings

### DIFF
--- a/includes/gutenberg/isc-image-block.js
+++ b/includes/gutenberg/isc-image-block.js
@@ -322,7 +322,7 @@
 	addFilter('editor.BlockEdit', 'image-source-control/editor', iscWithSourceControl);
 
 	$(function () {
-		var allLicences = iscData.option.licences.split("\n");
+		var allLicences = iscData.option.licences.replace(/[\r]/g, '').split("\n");
 		for (var i in allLicences) {
 			var label = allLicences[i].split('|');
 			licenceList.push({


### PR DESCRIPTION
This causes the "All Rights Reserved" and ultimately all licenses that don't come with a link to not work in ISC fields of Gutenberg.

fix #188