### PR TITLE
Include keyword “attributions” in ReadMe description

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -31,7 +31,7 @@ Choose between different credit displays:
 **Frontend Features**
 
 * Display image credits in the content, for image galleries, images added by shortcodes, and featured images
-* Define the layout and position of the image credits
+* Define the layout and position of those attributions
 * Attach the Per-page list automatically, by using a shortcode, or with a PHP function
 * Display image sources on archive pages
 * Block editor: detects image sources for the image, cover image, and gallery blocks


### PR DESCRIPTION
Update readme.txt to include keyword “attributions” in the plugin’s description. We missed this while switching tag “media” for “attributions” in #168.