### PR TITLE
Add ISC fields on cover block using featured image

### DIFF
--- a/includes/gutenberg/isc-image-block.js
+++ b/includes/gutenberg/isc-image-block.js
@@ -47,7 +47,7 @@
 
 				var id = props.attributes.id || props.attributes.mediaId;
 
-				if ( props.name === 'core/post-featured-image' ) {
+				if ( ( props.name === 'core/cover' && props.attributes.useFeaturedImage === true ) ||  props.name === 'core/post-featured-image' ) {
 					id = wp.data.select('core/editor').getEditedPostAttribute('featured_media');
 				}
 

--- a/readme.txt
+++ b/readme.txt
@@ -118,6 +118,10 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 == Changelog ==
 
+= untagged =
+
+- Feature: added ISC fields to Cover blocks using featured image.
+
 = 2.7.0 =
 
 - Feature: added ISC fields to Media & Text block


### PR DESCRIPTION
Add ISC field on cover block with the new "Use Featured Image" option enabled.

fixes #183