### PR TITLE
Update position of overlays after page fully loaded

### DIFF
--- a/public/assets/js/captions.js
+++ b/public/assets/js/captions.js
@@ -1,6 +1,7 @@
 if (document.readyState != 'loading') {
 	ISCready();
 } else {
+	// DOMContentLoaded fires after the content is loaded, but before scripts and images.
 	document.addEventListener( 'DOMContentLoaded', ISCready );
 }
 
@@ -24,6 +25,16 @@ function ISCready(){
 			}
 		}, 100 );
 
+		/**
+		 * Load image source positions after the page – including images – loaded completely
+		 * this resolves occasionally misplaced sources
+		 */
+		window.addEventListener( 'load', function() {
+			// the additional timeout seems needed to make it work reliably on Firefox
+			setTimeout( function(){
+				isc_update_captions_positions();
+			}, 100 );
+		} );
 		/**
 		 * Register resize event to check caption positions
 		 */

--- a/readme.txt
+++ b/readme.txt
@@ -123,6 +123,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 - Feature: added ISC fields to Cover blocks using featured image.
 - Feature: show feature image source string in the post excerpt block when the Insert below excerpts option is enabled
+- Improvement: check overlay positions after the site is fully loaded to correct misplaced overlays
 - Fix: specified style for overlay links to not also style other isc related links
 
 = 2.7.0 =


### PR DESCRIPTION
The position of the overlay was sometimes wrong, e.g., when using an image gallery with multiple images next to each other.
The fix just runs the position of the source again after the page is fully loaded, including scripts and images.