### PR TITLE
Change class of featured image source string

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -28,7 +28,6 @@ function isc_image_source( $attachment_id = 0 ) {
 /**
  * Return the source html of the featured image
  *
- * @since 1.8
  * @global object $my_isc isc class
  * @global object $post current post
  * @param integer $post_id id of the post; will use current post if empty.

--- a/public/public.php
+++ b/public/public.php
@@ -106,7 +106,7 @@ class ISC_Public extends ISC_Class {
 				<?php
 				// The 2022 theme adds display:block to the featured image block, which creates additional line breaks. `display: inline` fixes that.
 				?>
-				.isc-source-text a { display: inline; color: #fff; }
+				span.isc-source-text a { display: inline; color: #fff; }
 			</style>
 			<?php
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 = untagged =
 
 - Feature: added ISC fields to Cover blocks using featured image.
+- Fix: specified style for overlay links to not also style other isc related links
 
 = 2.7.0 =
 


### PR DESCRIPTION
Specified the CSS rule to style links in the source overlay, so that the links for featured images on excerpts are not styled as well. This caused them to be white on mostly white background.

Fixes #193