### PR TITLE
Full image list

### DIFF
--- a/public/assets/images/isc-icon-gray.svg
+++ b/public/assets/images/isc-icon-gray.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+	 x="0px" y="0px" width="256px" height="256px" viewBox="0 0 256 256"
+	 overflow="visible" enable-background="new 0 0.001 256 256" xml:space="preserve">
+<defs>
+</defs>
+<path fill="#CFD0D0" d="M254.281,249.582c1.086-1.881,1.719-4.058,1.719-6.386l-0.006-230.394c0-7.068-5.729-12.799-12.798-12.8
+	l-39.137,0c-1.085,0.003-2.188,0.145-3.286,0.438c-6.819,1.827-10.867,8.827-9.057,15.646l31.023,115.781v51.203l12.8-3.429
+	l3.313,12.364L64,238.854L17.147,64.001l144.886-38.834c6.827-1.83,10.88-8.848,9.05-15.677C169.56,3.801,164.436,0.041,158.82,0
+	L12.799,0.007c-4.74,0-8.868,2.583-11.08,6.413C0.633,8.301,0,10.479,0,12.807l0.006,230.394c0,4.74,2.583,8.87,6.412,11.082
+	c1.881,1.086,4.059,1.718,6.387,1.718l230.396-0.006C247.94,255.995,252.069,253.412,254.281,249.582z"/>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="8.9463" y1="33.3931" x2="166.1983" y2="-8.7425">
+	<stop  offset="0" style="stop-color:#CFD0D0"/>
+	<stop  offset="1" style="stop-color:#C5C6C6"/>
+</linearGradient>
+<path fill="url(#SVGID_1_)" d="M171.083,9.49C169.56,3.801,164.436,0.041,158.82,0L12.799,0.007c-4.74,0-8.868,2.583-11.08,6.413
+	l15.429,57.581l144.886-38.834C168.86,23.336,172.913,16.319,171.083,9.49z"/>
+<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="59.6133" y1="21.9355" x2="-2.037" y2="252.0174">
+	<stop  offset="0" style="stop-color:#D9DADA"/>
+	<stop  offset="1" style="stop-color:#C5C6C6"/>
+</linearGradient>
+<path fill="url(#SVGID_2_)" d="M0.006,243.201c0,4.74,2.583,8.87,6.412,11.082l57.58-15.428L17.146,64.002L1.717,6.422
+	C0.631,8.303,0,10.479,0,12.807L0.006,243.201z"/>
+<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="21.9326" y1="196.3877" x2="252.0154" y2="258.0382">
+	<stop  offset="0" style="stop-color:#D9DADA"/>
+	<stop  offset="1" style="stop-color:#C5C6C6"/>
+</linearGradient>
+<path fill="url(#SVGID_3_)" d="M243.2,255.995c4.74,0,8.869-2.583,11.081-6.413l-15.429-57.579L64,238.854L6.419,254.283
+	c1.881,1.086,4.058,1.718,6.386,1.718L243.2,255.995z"/>
+<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="278.4902" y1="243.0957" x2="212.6203" y2="-2.7343">
+	<stop  offset="0" style="stop-color:#CFD0D0"/>
+	<stop  offset="1" style="stop-color:#D9DADA"/>
+</linearGradient>
+<path fill="url(#SVGID_4_)" d="M255.994,12.802c0-7.068-5.729-12.799-12.798-12.8l-39.137,0c-1.085,0.003-2.188,0.145-3.286,0.438
+	c-6.819,1.827-10.867,8.827-9.057,15.646l31.023,115.781v51.203l12.8-3.429l18.741,69.942c1.086-1.881,1.719-4.058,1.719-6.386
+	L255.994,12.802z"/>
+<linearGradient id="SVGID_5_" gradientUnits="userSpaceOnUse" x1="181.4395" y1="25.1665" x2="181.4395" y2="2.486900e-14">
+	<stop  offset="0" style="stop-color:#F4F4F4"/>
+	<stop  offset="1" style="stop-color:#F4F4F4;stop-opacity:0"/>
+</linearGradient>
+<path fill="url(#SVGID_5_)" d="M204.06,0.002c-1.085,0.003-2.188,0.145-3.286,0.438c-6.819,1.827-10.867,8.827-9.057,15.646
+	l0.285,1.064l-29.969,8.017c6.827-1.83,10.88-8.848,9.05-15.677C169.56,3.801,164.436,0.041,158.82,0L204.06,0.002z"/>
+<linearGradient id="SVGID_6_" gradientUnits="userSpaceOnUse" x1="86.6211" y1="64.001" x2="86.6211" y2="7.105427e-14">
+	<stop  offset="0" style="stop-color:#C5C6C6"/>
+	<stop  offset="1" style="stop-color:#C5C6C6;stop-opacity:0"/>
+</linearGradient>
+<path fill="url(#SVGID_6_)" d="M171.083,9.49C169.56,3.801,164.436,0.041,158.82,0L12.799,0.007c-4.74,0-8.868,2.583-11.08,6.413
+	l15.429,57.581l144.886-38.834C168.86,23.336,172.913,16.319,171.083,9.49z"/>
+<linearGradient id="SVGID_7_" gradientUnits="userSpaceOnUse" x1="0" y1="130.3525" x2="63.998" y2="130.3525">
+	<stop  offset="0" style="stop-color:#C5C6C6;stop-opacity:0"/>
+	<stop  offset="1" style="stop-color:#C5C6C6"/>
+</linearGradient>
+<path fill="url(#SVGID_7_)" d="M0.006,243.201c0,4.74,2.583,8.87,6.412,11.082l57.58-15.428L17.146,64.002L1.717,6.422
+	C0.631,8.303,0,10.479,0,12.807L0.006,243.201z"/>
+<linearGradient id="SVGID_8_" gradientUnits="userSpaceOnUse" x1="130.3496" y1="192.0029" x2="130.3496" y2="256.001">
+	<stop  offset="0" style="stop-color:#C5C6C6"/>
+	<stop  offset="1" style="stop-color:#C5C6C6;stop-opacity:0"/>
+</linearGradient>
+<path fill="url(#SVGID_8_)" d="M243.2,255.995c4.74,0,8.869-2.583,11.081-6.413l-15.429-57.579L64,238.854L6.419,254.283
+	c1.881,1.086,4.058,1.718,6.386,1.718L243.2,255.995z"/>
+<path fill="#FFFFFF" d="M238.853,192.003L64,238.854L17.147,64.002L192.002,17.15l30.737,114.715l-30.861,8.269
+	c-13.191,3.535-21.021,17.095-17.485,30.288c3.535,13.194,17.096,21.021,30.287,17.486l30.86-8.268L238.853,192.003z"/>
+<linearGradient id="SVGID_9_" gradientUnits="userSpaceOnUse" x1="60.7754" y1="131.2896" x2="211.7744" y2="131.2896">
+	<stop  offset="0" style="stop-color:#C5C6C6"/>
+	<stop  offset="1" style="stop-color:#D9DADA"/>
+</linearGradient>
+<path fill="url(#SVGID_9_)" d="M116.105,140.847c-1.146,4.268-4.477,7.825-9.052,9.051c-4.575,1.225-9.234-0.189-12.362-3.31
+	l-5.278-5.28c-3.129-3.122-7.791-4.538-12.366-3.312c-4.576,1.227-7.906,4.783-9.054,9.051l-6.783,25.313
+	c-1.141,4.27-0.035,9.015,3.314,12.364c3.351,3.35,8.096,4.455,12.365,3.314l125.396-33.6c4.267-1.148,7.823-4.477,9.051-9.052
+	c1.225-4.576-0.189-9.236-3.312-12.365l-55.166-55.165c-3.128-3.12-7.787-4.536-12.362-3.31c-4.576,1.226-7.905,4.784-9.054,9.052
+	L116.105,140.847z"/>
+<linearGradient id="SVGID_10_" gradientUnits="userSpaceOnUse" x1="168.2754" y1="190.8726" x2="95.0084" y2="117.6055">
+	<stop  offset="0" style="stop-color:#C5C6C6"/>
+	<stop  offset="0.66" style="stop-color:#C5C6C6;stop-opacity:0"/>
+</linearGradient>
+<path fill="url(#SVGID_10_)" d="M116.105,140.847c-1.146,4.268-4.477,7.825-9.052,9.051c-4.575,1.225-9.234-0.189-12.362-3.31
+	l-5.278-5.28c-3.129-3.122-7.791-4.538-12.366-3.312c-4.576,1.227-7.906,4.783-9.054,9.051l-6.783,25.313
+	c-1.141,4.27-0.035,9.015,3.314,12.364c3.351,3.35,8.096,4.455,12.365,3.314l125.396-33.6c4.267-1.148,7.823-4.477,9.051-9.052
+	c1.225-4.576-0.189-9.236-3.312-12.365l-55.166-55.165c-3.128-3.12-7.787-4.536-12.362-3.31c-4.576,1.226-7.905,4.784-9.054,9.052
+	L116.105,140.847z"/>
+<linearGradient id="SVGID_11_" gradientUnits="userSpaceOnUse" x1="65.8906" y1="146.2227" x2="89.4131" y2="146.2227">
+	<stop  offset="0" style="stop-color:#CFD0D0"/>
+	<stop  offset="1" style="stop-color:#CFD0D0;stop-opacity:0"/>
+</linearGradient>
+<path fill="url(#SVGID_11_)" d="M89.413,141.308c-3.129-3.122-7.791-4.538-12.366-3.312c-4.576,1.227-7.906,4.783-9.054,9.051
+	l-2.103,7.842L89.413,141.308z"/>
+<linearGradient id="SVGID_12_" gradientUnits="userSpaceOnUse" x1="120.8438" y1="98.6338" x2="169.8652" y2="98.6338">
+	<stop  offset="0" style="stop-color:#D9DADA"/>
+	<stop  offset="1" style="stop-color:#D9DADA;stop-opacity:0"/>
+</linearGradient>
+<path fill="url(#SVGID_12_)" d="M169.865,94.862l-17.007-17.006c-3.128-3.12-7.787-4.536-12.362-3.31
+	c-4.576,1.226-7.905,4.784-9.054,9.052l-10.599,39.562L169.865,94.862z"/>
+<linearGradient id="SVGID_13_" gradientUnits="userSpaceOnUse" x1="-10.5703" y1="286.9487" x2="14.1646" y2="293.5764" gradientTransform="matrix(0.866 -0.5 0.5 0.866 -77.9382 -143.445)">
+	<stop  offset="0" style="stop-color:#D7D8D8"/>
+	<stop  offset="1" style="stop-color:#E1E1E1"/>
+</linearGradient>
+<circle fill="url(#SVGID_13_)" cx="68.75" cy="107.024" r="12.8"/>
+<linearGradient id="SVGID_14_" gradientUnits="userSpaceOnUse" x1="-11.375" y1="291.646" x2="12.9354" y2="298.1599" gradientTransform="matrix(0.866 -0.5 0.5 0.866 -77.9382 -143.445)">
+	<stop  offset="0" style="stop-color:#E1E1E1"/>
+	<stop  offset="1" style="stop-color:#E1E1E1;stop-opacity:0"/>
+</linearGradient>
+<path fill="url(#SVGID_14_)" d="M79.835,100.624c3.534,6.122,1.437,13.951-4.686,17.485c-6.122,3.535-13.95,1.437-17.485-4.685
+	L79.835,100.624z"/>
+<linearGradient id="SVGID_15_" gradientUnits="userSpaceOnUse" x1="185.958" y1="273.3066" x2="200.6825" y2="218.3515" gradientTransform="matrix(0.9659 -0.2588 0.2588 0.9659 -52.2007 -27.1034)">
+	<stop  offset="0" style="stop-color:#D7D8D8"/>
+	<stop  offset="1" style="stop-color:#E1E1E1"/>
+</linearGradient>
+<path fill="url(#SVGID_15_)" d="M222.74,131.865l-30.862,8.269c-13.191,3.535-21.021,17.095-17.485,30.288
+	c3.535,13.194,17.096,21.021,30.287,17.486l18.07-4.842L222.74,131.865z"/>
+<path fill="#FFFFFF" d="M194.011,148.087c-8.8,2.358-14.022,11.404-11.664,20.203c2.358,8.801,11.402,14.021,20.202,11.663
+	c8.799-2.358,14.022-11.401,11.664-20.202C211.854,150.953,202.811,145.73,194.011,148.087z M201.479,175.964
+	c-6.596,1.767-13.375-2.146-15.142-8.743c-1.769-6.597,2.146-13.376,8.742-15.145c6.596-1.768,13.376,2.147,15.144,8.744
+	S208.076,174.196,201.479,175.964z M205.411,168.139c-2.275,3.938-7.31,5.287-11.249,3.015c-3.939-2.276-5.29-7.31-3.015-11.251
+	c2.274-3.938,7.31-5.289,11.251-3.013l-2.054,3.555c-1.976-1.141-4.501-0.464-5.642,1.512c-1.141,1.975-0.463,4.5,1.513,5.641
+	c1.975,1.141,4.499,0.464,5.641-1.512L205.411,168.139z"/>
+</svg>

--- a/public/public.php
+++ b/public/public.php
@@ -718,9 +718,6 @@ class ISC_Public extends ISC_Class {
 	/**
 	 * Performs rendering of all attachments list
 	 *
-	 * @since 1.1.3
-	 * @update 1.5 added new method to get source
-	 *
 	 * @param array $atts attachments.
 	 */
 	public function display_all_attachment_list( $atts ) {
@@ -729,49 +726,7 @@ class ISC_Public extends ISC_Class {
 		}
 		$options = $this->get_isc_options();
 
-		/**
-		 * Added comment `isc_stop_overlay` as a class to the table to suppress overlays within it starting at that point
-		 * todo: allow overlays to start again after the table
-		 * todo: move to template file
-		 */
-		?>
-			<div class="isc_all_image_list_box isc_stop_overlay" style="overflow: scroll;">
-			<table>
-				<thead>
-				<?php if ( $options['thumbnail_in_list'] ) : ?>
-						<th><?php esc_html_e( 'Thumbnail', 'image-source-control-isc' ); ?></th>
-					<?php endif; ?>
-					<th><?php esc_html_e( 'Attachment’s ID', 'image-source-control-isc' ); ?></th>
-					<th><?php esc_html_e( 'Title', 'image-source-control-isc' ); ?></th>
-					<th><?php esc_html_e( 'Attached to', 'image-source-control-isc' ); ?></th>
-					<th><?php esc_html_e( 'Source', 'image-source-control-isc' ); ?></th>
-				</thead>
-				<tbody>
-			<?php foreach ( $atts as $id => $data ) : ?>
-					<?php
-						$source = $this->render_image_source_string( $id );
-					?>
-					<tr>
-						<?php
-							$v_align = '';
-						if ( $options['thumbnail_in_list'] ) :
-							$v_align = 'style="vertical-align: top;"';
-							?>
-							<?php if ( 'custom' !== $options['thumbnail_size'] ) : ?>
-								<td><?php echo wp_get_attachment_image( $id, $options['thumbnail_size'] ); ?></td>
-							<?php else : ?>
-								<td><?php echo wp_get_attachment_image( $id, array( $options['thumbnail_width'], $options['thumbnail_height'] ) ); ?></td>
-							<?php endif; ?>
-						<?php endif; ?>
-						<td <?php echo $v_align; ?>><?php echo $id; ?></td>
-						<td <?php echo $v_align; ?>><?php echo $data['title']; ?></td>
-						<td <?php echo $v_align; ?>><?php echo $data['posts']; ?></td>
-						<td <?php echo $v_align; ?>><?php echo $source; ?></td>
-					</tr>
-				<?php endforeach; ?>
-				</tbody>
-			</table></div>
-			<?php
+		require ISCPATH . 'public/views/global-list.php';
 	}
 
 	/**

--- a/public/public.php
+++ b/public/public.php
@@ -716,7 +716,7 @@ class ISC_Public extends ISC_Class {
 	}
 
 	/**
-	 * Performs rendering of all attachments list
+	 * Render the global list
 	 *
 	 * @param array $atts attachments.
 	 */
@@ -727,6 +727,28 @@ class ISC_Public extends ISC_Class {
 		$options = $this->get_isc_options();
 
 		require ISCPATH . 'public/views/global-list.php';
+	}
+
+	/**
+	 * Render global list thumbnails
+	 *
+	 * @param int $attachment_id attachment ID.
+	 */
+	public function render_global_list_thumbnail( $attachment_id ) {
+		$options = $this->get_isc_options();
+
+		if ( 'custom' !== $options['thumbnail_size'] ) {
+			$thumbnail = wp_get_attachment_image( $attachment_id, $options['thumbnail_size'] );
+		} else {
+			$thumbnail = wp_get_attachment_image( $attachment_id, array( $options['thumbnail_width'], $options['thumbnail_height'] ) );
+		}
+
+		// a thumbnail might be missing for images that are not hosted within WordPress
+		if ( ! $thumbnail  ) {
+			?><img src="<?php echo ISCBASEURL . '/public/assets/images/isc-icon-gray.svg' ?>"/><?php
+		}
+
+		echo $thumbnail;
 	}
 
 	/**

--- a/public/views/global-list.php
+++ b/public/views/global-list.php
@@ -29,13 +29,8 @@
 				$v_align = '';
 				if ( $options['thumbnail_in_list'] ) :
 					$v_align = 'style="vertical-align: top;"';
-					?>
-					<?php if ( 'custom' !== $options['thumbnail_size'] ) : ?>
-					<td><?php echo wp_get_attachment_image( $id, $options['thumbnail_size'] ); ?></td>
-				<?php else : ?>
-					<td><?php echo wp_get_attachment_image( $id, array( $options['thumbnail_width'], $options['thumbnail_height'] ) ); ?></td>
-				<?php endif; ?>
-				<?php endif; ?>
+					?><td><?php $this->render_global_list_thumbnail( $id ); ?></td><?php
+				endif; ?>
 				<td <?php echo $v_align; ?>><?php echo $id; ?></td>
 				<td <?php echo $v_align; ?>><?php echo $data['title']; ?></td>
 				<td <?php echo $v_align; ?>><?php echo $data['posts']; ?></td>

--- a/public/views/global-list.php
+++ b/public/views/global-list.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Render the global list of image sources
+ * @var array $options plugin options.
+ * @var array $atts attachment information.
+ *
+ * Added comment `isc_stop_overlay` as a class to the table to suppress overlays within it starting at that point
+ * todo: allow overlays to start again after the table
+ **/
+?>
+<div class="isc_all_image_list_box isc_stop_overlay" style="overflow: scroll;">
+	<table>
+		<thead>
+		<?php if ( $options['thumbnail_in_list'] ) : ?>
+			<th><?php esc_html_e( 'Thumbnail', 'image-source-control-isc' ); ?></th>
+		<?php endif; ?>
+		<th><?php esc_html_e( 'Attachment’s ID', 'image-source-control-isc' ); ?></th>
+		<th><?php esc_html_e( 'Title', 'image-source-control-isc' ); ?></th>
+		<th><?php esc_html_e( 'Attached to', 'image-source-control-isc' ); ?></th>
+		<th><?php esc_html_e( 'Source', 'image-source-control-isc' ); ?></th>
+		</thead>
+		<tbody>
+		<?php foreach ( $atts as $id => $data ) : ?>
+			<?php
+			$source = $this->render_image_source_string( $id );
+			?>
+			<tr>
+				<?php
+				$v_align = '';
+				if ( $options['thumbnail_in_list'] ) :
+					$v_align = 'style="vertical-align: top;"';
+					?>
+					<?php if ( 'custom' !== $options['thumbnail_size'] ) : ?>
+					<td><?php echo wp_get_attachment_image( $id, $options['thumbnail_size'] ); ?></td>
+				<?php else : ?>
+					<td><?php echo wp_get_attachment_image( $id, array( $options['thumbnail_width'], $options['thumbnail_height'] ) ); ?></td>
+				<?php endif; ?>
+				<?php endif; ?>
+				<td <?php echo $v_align; ?>><?php echo $id; ?></td>
+				<td <?php echo $v_align; ?>><?php echo $data['title']; ?></td>
+				<td <?php echo $v_align; ?>><?php echo $data['posts']; ?></td>
+				<td <?php echo $v_align; ?>><?php echo $source; ?></td>
+			</tr>
+		<?php endforeach; ?>
+		</tbody>
+	</table></div>

--- a/readme.txt
+++ b/readme.txt
@@ -124,6 +124,8 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 - Feature: added ISC fields to Cover blocks using featured image.
 - Feature: show feature image source string in the post excerpt block when the Insert below excerpts option is enabled
 - Improvement: check overlay positions after the site is fully loaded to correct misplaced overlays
+- Improvement: show a default thumbnail image in the global list, when WordPress didn’t create a thumbnail
+- Improvement: show a default thumbnail in WP Admin for [external images](https://imagesourcecontrol.com/documentation/#4-4-2-additional-images)
 - Fix: specified style for overlay links to not also style other isc related links
 
 = 2.7.0 =


### PR DESCRIPTION
Move global list template to a separate view file.
Show a default thumbnail in the global list for images for which WordPress doesn’t create a thumbnail, i.e., external images as imported by ISC Pro.