### PR TITLE
Prevent losing focus when saving on media modal

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -119,20 +119,21 @@ class ISC_Admin extends ISC_Class {
 		$screen = get_current_screen();
 
 		if ( isset( $screen->id ) ) {
-			if ( $screen->id === 'settings_page_isc-settings' ) {
-				wp_enqueue_script( 'isc_settings_script', plugins_url( '/assets/js/settings.js', __FILE__ ), array(), ISCVERSION, true );
-			}
-
-			if ( $screen->id === 'media_page_isc-sources' ) {
-				wp_enqueue_script( 'isc_sources_script', plugins_url( '/assets/js/sources.js', __FILE__ ), array(), ISCVERSION, true );
-			}
-
-			if ( in_array( $screen->id, array( 'upload', 'widgets', 'customize' ) ) ) {
-				wp_enqueue_script( 'isc_attachment_compat', plugins_url( '/assets/js/wp.media.view.AttachmentCompat.js', __FILE__ ), array( 'media-upload' ), ISCVERSION, true );
-			}
+			return;
+		}
+		if ( $screen->id === 'settings_page_isc-settings' ) {
+			wp_enqueue_script( 'isc_settings_script', plugins_url( '/assets/js/settings.js', __FILE__ ), array(), ISCVERSION, true );
 		}
 
-		// load CSS
+		if ( $screen->id === 'media_page_isc-sources' ) {
+			wp_enqueue_script( 'isc_sources_script', plugins_url( '/assets/js/sources.js', __FILE__ ), array(), ISCVERSION, true );
+		}
+
+		if ( in_array( $screen->id, array( 'upload', 'widgets', 'customize' ) ) ) {
+			wp_enqueue_script( 'isc_attachment_compat', plugins_url( '/assets/js/wp.media.view.AttachmentCompat.js', __FILE__ ), array( 'media-upload' ), ISCVERSION, true );
+		}
+
+		// Load CSS
 		if ( self::is_isc_page() ) {
 			wp_enqueue_style( 'isc_image_settings_css', plugins_url( '/assets/css/isc.css', __FILE__ ), false, ISCVERSION );
 		}

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -118,7 +118,7 @@ class ISC_Admin extends ISC_Class {
 	public function add_admin_scripts( $hook ) {
 		$screen = get_current_screen();
 
-		if ( isset( $screen->id ) ) {
+		if ( ! isset( $screen->id ) ) {
 			return;
 		}
 		if ( $screen->id === 'settings_page_isc-settings' ) {

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -117,12 +117,19 @@ class ISC_Admin extends ISC_Class {
 	 */
 	public function add_admin_scripts( $hook ) {
 		$screen = get_current_screen();
-		if ( isset( $screen->id ) && $screen->id === 'settings_page_isc-settings' ) {
-			wp_enqueue_script( 'isc_settings_script', plugins_url( '/assets/js/settings.js', __FILE__ ), array(), ISCVERSION, true );
-		}
 
-		if ( isset( $screen->id ) && $screen->id === 'media_page_isc-sources' ) {
-			wp_enqueue_script( 'isc_sources_script', plugins_url( '/assets/js/sources.js', __FILE__ ), array(), ISCVERSION, true );
+		if ( isset( $screen->id ) ) {
+			if ( $screen->id === 'settings_page_isc-settings' ) {
+				wp_enqueue_script( 'isc_settings_script', plugins_url( '/assets/js/settings.js', __FILE__ ), array(), ISCVERSION, true );
+			}
+
+			if ( $screen->id === 'media_page_isc-sources' ) {
+				wp_enqueue_script( 'isc_sources_script', plugins_url( '/assets/js/sources.js', __FILE__ ), array(), ISCVERSION, true );
+			}
+
+			if ( in_array( $screen->id, array( 'upload', 'widgets', 'customize' ) ) ) {
+				wp_enqueue_script( 'isc_attachment_compat', plugins_url( '/assets/js/wp.media.view.AttachmentCompat.js', __FILE__ ), array( 'media-upload' ), ISCVERSION, true );
+			}
 		}
 
 		// load CSS

--- a/admin/assets/js/wp.media.view.AttachmentCompat.js
+++ b/admin/assets/js/wp.media.view.AttachmentCompat.js
@@ -1,0 +1,27 @@
+( function ( wp ) {
+	/**
+	 * Extends wp.media.view.AttachmentCompat
+	 * Prevent re-rendering of custom attachments fields.
+	 * Fixes issue losing focus on attachment custom fields in the modal.
+	 *
+	 * https://core.trac.wordpress.org/ticket/40909
+	 */
+	const OriginalAttachmentCompat = wp.media.view.AttachmentCompat;
+	let fieldsRendered             = false;
+	wp.media.view.AttachmentCompat = OriginalAttachmentCompat.extend( {
+		dispose: function () {
+			OriginalAttachmentCompat.prototype.dispose.apply( this, arguments );
+			fieldsRendered = false;
+		},
+		render:  function () {
+			const compat = this.model.get( 'compat' );
+			if ( fieldsRendered ) {
+				return;
+			}
+			OriginalAttachmentCompat.prototype.render.apply( this, arguments );
+			if ( compat && compat.item && compat.item.indexOf( 'isc_image_source' ) !== - 1 ) {
+				fieldsRendered = true;
+			}
+		}
+	} );
+} )( window.wp );

--- a/includes/gutenberg/gutenberg.php
+++ b/includes/gutenberg/gutenberg.php
@@ -114,7 +114,9 @@ class Isc_Gutenberg {
 	 */
 	public function editor_assets() {
 		$dependencies = array( 'jquery', 'wp-api', 'lodash', 'wp-blocks', 'wp-element', 'wp-i18n' );
-		$screen = get_current_screen();
+		$screen       = get_current_screen();
+		wp_enqueue_script( 'isc_attachment_compat', trailingslashit( ISCBASEURL ) . 'admin/assets/js/wp.media.view.AttachmentCompat.js', array( 'media-upload' ), ISCVERSION, true );
+
 		if ( $screen && isset( $screen->base ) && $screen->base !== 'widgets' ) {
 			$dependencies[] = 'wp-editor';
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -123,6 +123,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 - Feature: added ISC fields to Cover blocks using featured image.
 - Feature: show feature image source string in the post excerpt block when the Insert below excerpts option is enabled
+- Improvement: prevent losing focus on attachment fields in the media modal when saving data
 - Improvement: check overlay positions after the site is fully loaded to correct misplaced overlays
 - Improvement: show a default thumbnail image in the global list, when WordPress didn’t create a thumbnail
 - Improvement: show a default thumbnail in WP Admin for [external images](https://imagesourcecontrol.com/documentation/#4-4-2-additional-images)


### PR DESCRIPTION
When editing attachment fields in the media modal, focus is lost after saving if the field is entered by tabbing or clicking on it when the previously edited field still has focus

fix #197