### PR TITLE
added isc_public_global_list_view_path filter

### DIFF
--- a/public/public.php
+++ b/public/public.php
@@ -726,7 +726,7 @@ class ISC_Public extends ISC_Class {
 		}
 		$options = $this->get_isc_options();
 
-		require ISCPATH . 'public/views/global-list.php';
+		require apply_filters( 'isc_public_global_list_view_path', ISCPATH . 'public/views/global-list.php' );
 	}
 
 	/**


### PR DESCRIPTION
The `isc_public_global_list_view_path` was added to allow users to build their own template for the global list view.