### PR TITLE
Preload image data on image selection

### DIFF
--- a/admin/assets/js/media-upload.js
+++ b/admin/assets/js/media-upload.js
@@ -1,0 +1,13 @@
+( function ( wp ) {
+	if ( wp.media ) {
+		// Ensure that the Modal is ready.
+		wp.media.view.Modal.prototype.on( 'ready', function () {
+			wp.media.view.Modal.prototype.on( 'open', function () {
+				wp.media.frame.state().get( 'selection' ).on( 'selection:single', function ( event ) {
+					wp.data.select( 'core' ).getEntityRecord( 'postType', 'attachment', event.id );
+				} );
+			} );
+		} );
+	}
+
+} )( window.wp );

--- a/includes/gutenberg/gutenberg.php
+++ b/includes/gutenberg/gutenberg.php
@@ -141,6 +141,8 @@ class Isc_Gutenberg {
 			wp_add_inline_script( 'isc/image-block', 'var iscData = ' . wp_json_encode( $isc_data ) . ';', 'before' );
 		}
 		wp_enqueue_script( 'isc/image-block' );
+
+		wp_enqueue_script( 'isc/media-upload', trailingslashit( ISCBASEURL ) . 'admin/assets/js/media-upload.js', array( 'media-upload' ), ISCVERSION, true );
 	}
 
 }


### PR DESCRIPTION
Load image meta data as soon as it is selected on the media modal.

Fix #200