### PR TITLE
disable file extension check

### DIFF
--- a/includes/model.php
+++ b/includes/model.php
@@ -533,7 +533,11 @@ class ISC_Model {
 		$ext = pathinfo( $url, PATHINFO_EXTENSION );
 		if ( ! $ext ) {
 			ISC_Log::log( 'exit get_image_by_url() no extension found' );
-			return 0;
+			if ( apply_filters( 'isc_allow_empty_file_extension', __return_false() ) ) {
+				ISC_Log::log( "get_image_by_url() didn’t find an extension for $url but continues." );
+			} else {
+				return 0;
+			}
 		}
 		/**
 		 * Check for the format 'image-title-(e12452112-)300x200.jpg(?query…)' and removes

--- a/readme.txt
+++ b/readme.txt
@@ -127,6 +127,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 - Improvement: show a default thumbnail image in the global list, when WordPress didn’t create a thumbnail
 - Improvement: show a default thumbnail in WP Admin for [external images](https://imagesourcecontrol.com/documentation/#4-4-2-additional-images)
 - Improvement: added CSS rule to Overlay for better compatibility with Divi theme
+- Improvement: (Pro) Find images without a file extension
 - Fix: specified style for overlay links to not also style other isc related links
 
 = 2.7.0 =


### PR DESCRIPTION
Introduced the `isc_allow_empty_file_extension` that allows developers to disable the file extension check.