### PR TITLE
Move global list shortcode attributes into options

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -150,7 +150,8 @@ class ISC_Admin extends ISC_Class {
 		// add style to media edit pages
 		if ( isset( $screen->id ) && $screen->id === 'attachment' ) {
 			// Meta field in media view
-			?><style>
+			?>
+			<style>
 				.compat-attachment-fields input[type="text"] { width: 100%; }
 				.compat-attachment-fields th { vertical-align: top; }
 			</style>
@@ -159,12 +160,15 @@ class ISC_Admin extends ISC_Class {
 		// add style to plugin overview page
 		if ( isset( $screen->id ) && $screen->id === 'plugins' ) {
 			// Meta field in media view
-			?><style>
+			?>
+			<style>
 				.row-actions .isc-get-pro { font-weight: bold; color: #F70; }
-			</style><?php
+			</style>
+			<?php
 		}
 		// add to any backend pages
-		?><style>
+		?>
+		<style>
 			.compat-attachment-fields .isc-get-pro{ font-weight: bold; color: #F70; }
 			div.error.isc-notice { border-left-color: #F70; }
 		</style>
@@ -188,11 +192,10 @@ class ISC_Admin extends ISC_Class {
 	 * @return array with form fields
 	 */
 	public function add_isc_fields( $form_fields, $post ) {
-
 		if ( ! class_exists( 'ISC_Pro_Admin', false ) ) {
 			$form_fields['isc_image_source_pro']['label'] = '';
 			$form_fields['isc_image_source_pro']['input'] = 'html';
-			$form_fields['isc_image_source_pro']['html'] = self::get_pro_link( 'attachment-edit');
+			$form_fields['isc_image_source_pro']['html']  = self::get_pro_link( 'attachment-edit' );
 		}
 
 		// add input field for source
@@ -248,13 +251,12 @@ class ISC_Admin extends ISC_Class {
 	 * Create the menu pages for ISC with access for editors and higher roles
 	 */
 	public function add_menu_items() {
-
 		$options = $this->get_isc_options();
 		if ( empty( $options['warning_onesource_missing'] ) ) {
 			$notice_alert = '';
 		} else {
 			$missing_images = get_transient( 'isc-show-missing-sources-warning' );
-			$notice_alert = '&nbsp;<span class="update-plugins count-' . $missing_images . '"><span class="update-count">' . $missing_images . '</span></span>';
+			$notice_alert   = '&nbsp;<span class="update-plugins count-' . $missing_images . '"><span class="update-count">' . $missing_images . '</span></span>';
 		}
 
 		add_submenu_page(
@@ -263,7 +265,8 @@ class ISC_Admin extends ISC_Class {
 			__( 'Image Sources', 'image-source-control-isc' ) . $notice_alert,
 			'edit_others_posts',
 			'isc-sources',
-			array( $this, 'render_sources_page' ) );
+			array( $this, 'render_sources_page' )
+		);
 
 		add_options_page(
 			__( 'Image Source Control Settings', 'image-source-control-isc' ),
@@ -284,13 +287,13 @@ class ISC_Admin extends ISC_Class {
 			return;
 		}
 		switch ( $screen_id ) {
-			case 'settings_page_isc-settings' :
+			case 'settings_page_isc-settings':
 				$title = __( 'Settings', 'image-source-control-isc' );
 				break;
-			case 'media_page_isc-sources' :
+			case 'media_page_isc-sources':
 				$title = __( 'Tools', 'image-source-control-isc' );
 				break;
-			default :
+			default:
 				$title = get_admin_page_title();
 		}
 		include ISCPATH . 'admin/templates/header.php';
@@ -323,6 +326,8 @@ class ISC_Admin extends ISC_Class {
 
 		// Global list group
 		add_settings_section( 'isc_settings_section_complete_list', '3. ' . __( 'Global list', 'image-source-control-isc' ), '__return_false', 'isc_settings_page' );
+		add_settings_field( 'global_list_included_images', __( 'Included images', 'image-source-control-isc' ), array( $this, 'renderfield_global_list_included_images' ), 'isc_settings_page', 'isc_settings_section_complete_list' );
+		add_settings_field( 'images_per_page_in_list', __( 'Images per page', 'image-source-control-isc' ), array( $this, 'renderfield_images_per_page_in_list' ), 'isc_settings_page', 'isc_settings_section_complete_list' );
 		add_settings_field( 'thumbnail_in_list', __( 'Use thumbnails', 'image-source-control-isc' ), array( $this, 'renderfield_thumbnail_in_list' ), 'isc_settings_page', 'isc_settings_section_complete_list' );
 		add_settings_field( 'thumbnail_width', __( 'Thumbnails max-width', 'image-source-control-isc' ), array( $this, 'renderfield_thumbnail_width' ), 'isc_settings_page', 'isc_settings_section_complete_list' );
 		add_settings_field( 'thumbnail_height', __( 'Thumbnails max-height', 'image-source-control-isc' ), array( $this, 'renderfield_thumbnail_height' ), 'isc_settings_page', 'isc_settings_section_complete_list' );
@@ -432,7 +437,6 @@ class ISC_Admin extends ISC_Class {
 	 * Missing sources page callback
 	 */
 	public function render_sources_page() {
-
 		$storage_model = new ISC_Storage_Model();
 		$storage_size  = count( $storage_model->get_storage() );
 
@@ -520,6 +524,25 @@ class ISC_Admin extends ISC_Class {
 		$included_images         = ! empty( $options['overlay_included_images'] ) ? $options['overlay_included_images'] : '';
 		$included_images_options = $this->get_overlay_included_images_options();
 		require_once ISCPATH . '/admin/templates/settings/overlay-included-images.php';
+	}
+
+	/**
+	 * Render option to define which images should show in the global list
+	 */
+	public function renderfield_global_list_included_images() {
+		$options                 = $this->get_isc_options();
+		$included_images         = ! empty( $options['global_list_included_images'] ) ? $options['global_list_included_images'] : '';
+		$included_images_options = $this->get_global_list_included_images_options();
+		require_once ISCPATH . '/admin/templates/settings/global-list-included-images.php';
+	}
+
+	/**
+	 * Render option for the number of images per page in the Global list
+	 */
+	public function renderfield_images_per_page_in_list() {
+		$options         = $this->get_isc_options();
+		$images_per_page = isset( $options['images_per_page'] ) ? absint( $options['images_per_page'] ) : 99999;
+		require_once ISCPATH . '/admin/templates/settings/images-per-page.php';
 	}
 
 	/**
@@ -725,7 +748,7 @@ class ISC_Admin extends ISC_Class {
 
 		ISC_Storage_Model::clear_storage();
 
-		die( esc_html__( "Storage deleted", 'image-source-control-isc' ) );
+		die( esc_html__( 'Storage deleted', 'image-source-control-isc' ) );
 	}
 
 	/**
@@ -751,6 +774,7 @@ class ISC_Admin extends ISC_Class {
 		} else {
 			$output['licences'] = false;
 		}
+		$output['images_per_page']     = absint ( $input['images_per_page'] );
 		if ( isset( $input['thumbnail_in_list'] ) ) {
 			$output['thumbnail_in_list'] = true;
 			if ( in_array( $input['thumbnail_size'], $this->thumbnail_size ) ) {
@@ -788,6 +812,7 @@ class ISC_Admin extends ISC_Class {
 		}
 		$output['list_included_images']    = isset( $input['list_included_images'] ) ? esc_attr( $input['list_included_images'] ) : '';
 		$output['overlay_included_images'] = isset( $input['overlay_included_images'] ) ? esc_attr( $input['overlay_included_images'] ) : '';
+		$output['global_list_included_images'] = isset( $input['global_list_included_images'] ) ? esc_attr( $input['global_list_included_images'] ) : '';
 
 		/**
 		 * 2.0 moved the options to handle "own images" into "standard sources" and only offers a single choice for one of the options now
@@ -832,7 +857,7 @@ class ISC_Admin extends ISC_Class {
 	 *
 	 * @return string website URL
 	 */
-	public static function get_isc_website_url( ) {
+	public static function get_isc_website_url() {
 		// check if the locale starts with "de_"
 		if ( strpos( determine_locale(), 'de_' ) === 0 ) {
 			return 'https://imagesourcecontrol.de/';

--- a/admin/templates/settings/global-list-included-images.php
+++ b/admin/templates/settings/global-list-included-images.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Render the Included Images option for the Global List
+ *
+ * @var string|bool $included_images value of the "global_list_included_images" option.
+ * @var array $included_images_options information about the available options.
+ */
+?>
+<p class="description"><?php esc_html_e( 'Choose which images should be included in the global list.', 'image-source-control-isc' ); ?></p>
+<div class="isc-settings-highlighted">
+	<?php
+	foreach ( $included_images_options as $_key => $_options ) :
+		$value  = isset( $_options['value'] ) ? $_options['value'] : '';
+		$is_pro = ! empty( $_options['is_pro'] );
+		?>
+		<label>
+			<input type="radio" name="isc_options[global_list_included_images]" value="<?php echo esc_attr( $value ); ?>"
+				<?php checked( $included_images, $value ); ?>
+				<?php echo $is_pro ? 'disabled="disabled" class="is-pro"' : ''; ?>
+			/>
+			<?php if ( $is_pro ) : echo ISC_Admin::get_pro_link( 'global-list-' . sanitize_title( $_options['label'] ) ); endif; ?>
+			<?php echo isset( $_options['label'] ) ? esc_html( $_options['label'] ) : ''; ?>
+		</label>
+			<?php
+			if ( isset( $_options['description'] ) ) :
+				?>
+		<p class="description">
+				<?php
+				echo wp_kses(
+					$_options['description'],
+					array(
+						'code' => array(),
+					)
+				);
+				?>
+		</p>
+				<?php
+			endif;
+			?>
+	<?php endforeach; ?>
+</div>

--- a/admin/templates/settings/images-per-page.php
+++ b/admin/templates/settings/images-per-page.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Render the Images per page setting
+ *
+ * @var array $images_per_page number of images to display per page.
+ */
+?>
+<input type="number" id='images-per-page' name="isc_options[images_per_page]" value="<?php echo esc_attr( $images_per_page ); ?>" />
+<p class="description"><?php esc_html_e( 'The number of entries that are visible in the global list before a pagination is added.', 'image-source-control-isc' ); ?>
+ <?php esc_html_e( 'Use 0 to show all entries.', 'image-source-control-isc' ); ?></p>

--- a/admin/templates/settings/source-type-all.php
+++ b/admin/templates/settings/source-type-all.php
@@ -16,35 +16,14 @@
 		)
 	);
 	?>
-	 <?php
-		esc_html_e( 'By default, it lists only images that are actively used within post and page content.', 'image-source-control-isc' );
-		?>
 </p>
 <p>
 	<?php
 	printf(
-	// translators: %s is a shortcode.
-		esc_html__( 'Use %s to show only a limited number of images per page.', 'image-source-control-isc' ),
-		wp_kses(
-			'<code>[isc_list_all per_page="25"]</code>',
-			array(
-				'code' => array(),
-			)
-		)
-	);
-	?>
-</p>
-<p>
-	<?php
-	printf(
-	// translators: %s is a shortcode.
-		esc_html__( 'Use %s to show all images in the Media library, regardless of whether they are placed within post content or not.', 'image-source-control-isc' ),
-		wp_kses(
-			'<code>[isc_list_all included="all"]</code>',
-			array(
-				'code' => array(),
-			)
-		)
+	// translators: %s is an starting link tag. %s is a closing link tag
+		esc_html__( 'See the %1$sGlobal list%2$s settings to control the output.', 'image-source-control-isc' ),
+		'<a href="#isc_settings_section_complete_list">',
+		'</a>'
 	);
 	?>
 </p>

--- a/includes/model.php
+++ b/includes/model.php
@@ -363,6 +363,23 @@ class ISC_Model {
 		return $count;
 	}
 
+	/**
+	 * Get attachments.
+	 * Allows to be called with custom arguments.
+	 *
+	 * @param array $args arguments for the query.
+	 * @return array with attachments. Returns all attachments in the Media Library if called without additional arguments.
+	 */
+	public static function get_attachments( $args ) {
+		$args = wp_parse_args( $args, array(
+			'post_type'   => 'attachment',
+			'numberposts' => -1,
+			'post_status' => null,
+			'post_parent' => null,
+		) );
+
+		return get_posts( $args );
+	}
 
 	/**
 	 * Get all attachments with empty sources options.
@@ -546,7 +563,7 @@ class ISC_Model {
 		// $types = implode( '|', ISC_Class::get_instance()->allowed_extensions );
 		// $newurl = esc_url( preg_replace( "/(-e\d+){0,1}(-\d+x\d+){0,1}\.({$types})(.*)/i", '.${3}', $url ) );
 		// this is how WordPress core is detecting changed image URLs
-		$newurl = esc_url( preg_replace( "/-(?:\d+x\d+|scaled|rotated)\.{$ext}(.*)/i", '.' . $ext, $url ) );
+		$newurl   = esc_url( preg_replace( "/-(?:\d+x\d+|scaled|rotated)\.{$ext}(.*)/i", '.' . $ext, $url ) );
 		$orig_url = $url;
 
 		$storage = new ISC_Storage_Model();

--- a/isc.class.php
+++ b/isc.class.php
@@ -198,6 +198,7 @@ GFDL GNU Free Documentation License 1.3|https://www.gnu.org/licenses/fdl-1.3.htm
 			$default['list_on_excerpts']          = false;
 			$default['image_list_headline']       = __( 'image sources', 'image-source-control-isc' );
 			$default['version']                   = ISCVERSION;
+			$default['images_per_page']			  = 99999;
 			$default['thumbnail_in_list']         = false;
 			$default['thumbnail_size']            = 'thumbnail';
 			$default['thumbnail_width']           = 150;
@@ -356,6 +357,33 @@ GFDL GNU Free Documentation License 1.3|https://www.gnu.org/licenses/fdl-1.3.htm
 			);
 
 			return apply_filters( 'isc_overlay_included_images_options', $included_images_options );
+		}
+
+		/**
+		 * Get the options for images that appear in the global list
+		 */
+		public function get_global_list_included_images_options() {
+			$included_images_options = array(
+				'in_posts'  => array(
+					'label'       => __( 'Images in the content', 'image-source-control-isc' ),
+					'description' => __( 'Only images that are actively used within the post and page content.', 'image-source-control-isc' ),
+					'value'       => '',
+				),
+				'all' => array(
+					'label'       => __( 'All images', 'image-source-control-isc' ),
+					'description' => __( 'All images in the Media library, regardless of whether they are placed within post content or not.', 'image-source-control-isc' ),
+					'value'       => 'all',
+					'is_pro'      => false,
+				),
+				'with_sources' => array(
+					'label'       => __( 'Images with sources', 'image-source-control-isc' ),
+					'description' => __( 'All images in the Media library that have an individual source or use the standard source.', 'image-source-control-isc' ),
+					'value'       => 'with_sources',
+					'is_pro'      => true,
+				),
+			);
+
+			return apply_filters( 'isc_global_list_included_images_options', $included_images_options );
 		}
 
 		/**

--- a/public/public.php
+++ b/public/public.php
@@ -592,32 +592,41 @@ class ISC_Public extends ISC_Class {
 	 * @return string
 	 */
 	public function list_all_post_attachments_sources_shortcode( $atts = array() ) {
+		$options = $this->get_isc_options();
+
 		$a = shortcode_atts(
 			array(
-				'per_page'     => 99999,
+				'per_page'     => null,
 				'before_links' => '',
 				'after_links'  => '',
 				'prev_text'    => '&#171; Previous',
 				'next_text'    => 'Next &#187;',
-				'included'     => 'displayed',
+				'included'     => null,
 			),
 			$atts
 		);
+
+		// How many entries per page. Use plugin options or default, if the shortcode attribute is missing.
+		if ( $a['per_page'] === null ) {
+			$per_page = isset( $options['images_per_page'] ) ? absint( $options['images_per_page'] ) : 99999;
+		} else {
+			$per_page = absint( $a['per_page'] );
+		}
+
+		// Which types of images are included? Use plugin options or default, if the shortcode attribute is missing.
+		if ( $a['included'] === null ) {
+			$included = isset( $options['global_list_included_images'] ) ? $options['global_list_included_images'] : '';
+		} else {
+			$included = $a['included'];
+		}
 
 		// use proper translation if attribute is not given
 		$prev_text = '&#171; Previous' === $a['prev_text'] ? __( '&#171; Previous', 'image-source-control-isc' ) : $a['prev_text'];
 		$next_text = 'Next &#187;' === $a['next_text'] ? __( 'Next &#187;', 'image-source-control-isc' ) : $a['next_text'];
 
-		// retrieve all attachments
-		$args = array(
-			'post_type'   => 'attachment',
-			'numberposts' => -1,
-			'post_status' => null,
-			'post_parent' => null,
-		);
-
-		// check mode
-		if ( 'all' !== $a['included'] ) {
+		// check which images are included
+		$args = array();
+		if ( 'all' !== $included ) {
 			// only load images attached to posts
 			$args['meta_query'] = array(
 				array(
@@ -628,7 +637,8 @@ class ISC_Public extends ISC_Class {
 			);
 		}
 
-		$attachments = get_posts( $args );
+		$attachments = ISC_Model::get_attachments( apply_filters( 'isc_global_list_get_attachment_arguments', $args ) );
+
 		if ( empty( $attachments ) ) {
 			return '';
 		}
@@ -671,7 +681,7 @@ class ISC_Public extends ISC_Class {
 						);
 					}
 				}
-				if ( 'all' !== $a['included'] && $usage_data_array === array() ) {
+				if ( 'all' !== $included && $usage_data_array === array() ) {
 					unset( $connected_atts[ $_attachment->ID ] );
 					continue;
 				}
@@ -693,7 +703,6 @@ class ISC_Public extends ISC_Class {
 
 		$up_limit = 1;
 
-		$per_page = absint( $a['per_page'] );
 		if ( $per_page && $per_page < $total ) {
 			$rem      = $total % $per_page; // The Remainder of $total / $per_page
 			$up_limit = ( $total - $rem ) / $per_page;

--- a/readme.txt
+++ b/readme.txt
@@ -123,6 +123,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 - Feature: added ISC fields to Cover blocks using featured image.
 - Feature: show feature image source string in the post excerpt block when the Insert below excerpts option is enabled
+- Improvement: the Global List settings show options for which images are included and how many per page. The appropriate shortcode attributes override them, if set.
 - Improvement: check overlay positions after the site is fully loaded to correct misplaced overlays
 - Improvement: show a default thumbnail image in the global list, when WordPress didn’t create a thumbnail
 - Improvement: show a default thumbnail in WP Admin for [external images](https://imagesourcecontrol.com/documentation/#4-4-2-additional-images)


### PR DESCRIPTION
The Global List shortcode used some attributes to control which images it showed and how many per page. These were now moved into options in the settings. If the `included` or `per_page` attributes are set in the shortcode, they will override the global settings.

The appropriate explanation and examples in the settings were also removed.