### PR TITLE
Add support for Elementor background images

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -349,6 +349,9 @@ class ISC_Admin extends ISC_Class {
 		// Misc settings group
 		add_settings_section( 'isc_settings_section_misc', __( 'Miscellaneous settings', 'image-source-control-isc' ), '__return_false', 'isc_settings_page' );
 		add_settings_field( 'standard_source', __( 'Standard source', 'image-source-control-isc' ), array( $this, 'renderfield_standard_source' ), 'isc_settings_page', 'isc_settings_section_misc' );
+		if ( defined( 'ELEMENTOR_VERSION' ) ) {
+			add_settings_field( 'elementor', __( 'Elementor', 'image-source-control-isc' ), array( $this, 'renderfield_elementor' ), 'isc_settings_page', 'isc_settings_section_misc' );
+		}
 		add_settings_field( 'warning_one_source', __( 'Warn about missing sources', 'image-source-control-isc' ), array( $this, 'renderfield_warning_source_missing' ), 'isc_settings_page', 'isc_settings_section_misc' );
 		add_settings_field( 'enable_log', __( 'Debug log', 'image-source-control-isc' ), array( $this, 'renderfield_enable_log' ), 'isc_settings_page', 'isc_settings_section_misc' );
 		add_settings_field( 'remove_on_uninstall', __( 'Delete data on uninstall', 'image-source-control-isc' ), array( $this, 'renderfield_remove_on_uninstall' ), 'isc_settings_page', 'isc_settings_section_misc' );
@@ -644,6 +647,17 @@ class ISC_Admin extends ISC_Class {
 		require_once ISCPATH . '/admin/templates/settings/standard-source.php';
 
 		do_action( 'isc_admin_settings_template_after_standard_source' );
+	}
+
+	/**
+	 * Render option for Elementor support
+	 */
+	public function renderfield_elementor() {
+		if ( ! class_exists( 'ISC_Pro_Admin', false ) ) {
+			require_once ISCPATH . '/admin/templates/settings/elementor.php';
+		}
+
+		do_action( 'isc_admin_settings_template_after_elementor' );
 	}
 
 	/**

--- a/admin/templates/settings/elementor.php
+++ b/admin/templates/settings/elementor.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Render the Elementor setting
+ */
+?>
+<label>
+	<input type="checkbox" disabled="disabled">
+	<?php echo ISC_Admin::get_pro_link( 'elementor' ); ?>
+	<?php esc_html_e( 'Enable support for Elementor background images.', 'image-source-control-isc' ); ?>
+</label>

--- a/includes/model.php
+++ b/includes/model.php
@@ -486,7 +486,7 @@ class ISC_Model {
 	 * Filter image ids from content
 	 *
 	 * @param string $content post content.
-	 * @return array with image ids => image src uri-s
+	 * @return string[] with image ids => image src uri-s
 	 */
 	public static function filter_image_ids( $content = '' ) {
 		$srcs = array();
@@ -558,7 +558,15 @@ class ISC_Model {
 			}
 		}
 
-		return $srcs;
+		/**
+		 * Filter image IDs found in HTML content, or add new ones based on other rules.
+		 *
+		 * @since 2.9.0
+		 *
+		 * @param string[] $srcs image sources with image ids => image src uri
+		 * @param string $content any HTML document
+		 */
+		return apply_filters( 'isc_filter_image_ids_from_content', $srcs, $content );
 	}
 
 	/**

--- a/public/public.php
+++ b/public/public.php
@@ -349,7 +349,7 @@ class ISC_Public extends ISC_Class {
 			$alignment = isset( $matches_align[0] ) ? $matches_align[0] : '';
 
 			$old_content   = $_match[3];
-			$source        = $options['source_pretext'] . ' ' . $source_string;
+			$source        = ! empty( $options['source_pretext'] ) ? $options['source_pretext'] . ' ' . $source_string : $source_string;
 			$markup_before = '';
 			$markup_after  = '';
 

--- a/readme.txt
+++ b/readme.txt
@@ -123,8 +123,9 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 = untagged =
 
-- Improvement: Route all calls to update_post_meta through the same internal function for better debugging
-- Improvement: Introduced the `isc_update_post_meta` action to hook into post meta updates
+- Improvement: route all calls to update_post_meta through the same internal function for better debugging
+- Improvement: introduced the `isc_update_post_meta` action to hook into post meta updates
+- Improvement: the new `isc_filter_image_ids_from_content` filter allows custom image ID filtering from the content
 
 = 2.8.0 =
 


### PR DESCRIPTION
Prepare the appropriate option in Pro

Add the `isc_filter_image_ids_from_content` filter for image IDs found in the content or any HTML output.