### PR TITLE
Remove translation for Elementor

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -348,7 +348,7 @@ class ISC_Admin extends ISC_Class {
 		add_settings_field( 'standard_source', __( 'Standard source', 'image-source-control-isc' ), array( $this, 'renderfield_standard_source' ), 'isc_settings_page', 'isc_settings_section_misc' );
 		add_settings_field( 'block_options', __( 'Block options', 'image-source-control-isc' ), array( $this, 'renderfield_block_options' ), 'isc_settings_page', 'isc_settings_section_misc' );
 		if ( defined( 'ELEMENTOR_VERSION' ) ) {
-			add_settings_field( 'elementor', __( 'Elementor', 'image-source-control-isc' ), array( $this, 'renderfield_elementor' ), 'isc_settings_page', 'isc_settings_section_misc' );
+			add_settings_field( 'elementor', 'Elementor', array( $this, 'renderfield_elementor' ), 'isc_settings_page', 'isc_settings_section_misc' );
 		}
 		add_settings_field( 'warning_one_source', __( 'Warn about missing sources', 'image-source-control-isc' ), array( $this, 'renderfield_warning_source_missing' ), 'isc_settings_page', 'isc_settings_section_misc' );
 		add_settings_field( 'enable_log', __( 'Debug log', 'image-source-control-isc' ), array( $this, 'renderfield_enable_log' ), 'isc_settings_page', 'isc_settings_section_misc' );

--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,10 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 == Changelog ==
 
+= untagged =
+
+- Improvement: remove translation for the brand ”Elementor”
+
 = 2.9.0 =
 
 - Improvement: (Pro) manage and display the image source for Elementor background images


### PR DESCRIPTION
The term "Elementor" should not be translationable since it is a brand without translations. This PR removes the translation syntax when the term is used stand-alone.