### PR TITLE
Show ISC fields on media frame on `upload.php` only

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -200,6 +200,9 @@ class ISC_Admin extends ISC_Class {
 	 * @return array with form fields
 	 */
 	public function add_isc_fields( $form_fields, $post ) {
+		if ( strpos( sanitize_text_field( $_SERVER['HTTP_REFERER'] ), 'wp-admin/upload.php' ) === false ) {
+			return $form_fields;
+		}
 		if ( ! class_exists( 'ISC_Pro_Admin', false ) ) {
 			$form_fields['isc_image_source_pro']['label'] = '';
 			$form_fields['isc_image_source_pro']['input'] = 'html';

--- a/readme.txt
+++ b/readme.txt
@@ -125,6 +125,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 = untagged =
 
+- Improvement: remove ISC fields from media frame when it is not loaded from the media library page to prevent confusions
 - Improvement: remove translation for the brand ”Elementor”
 
 = 2.9.0 =


### PR DESCRIPTION
remove ISC fields from media frame when it is not loaded from the media library page to prevent confusion.

Fix #217