### PR TITLE
Limit checks for empty sources

### DIFF
--- a/admin/templates/sources.php
+++ b/admin/templates/sources.php
@@ -10,6 +10,15 @@ $attachments = ISC_Model::get_attachments_with_empty_sources();
 if ( ! empty( $attachments ) ) :
 	?>
 	<h2><?php esc_html_e( 'Images without sources', 'image-source-control-isc' ); ?></h2>
+	<?php if( count( $attachments ) >= ISC_Model::MAX_POSTS ) : ?>
+		<p><?php
+			printf(
+				// translators: %d is the number of entries in the following table
+				esc_html__( 'The list only shows the last %d images.', 'image-source-control-isc' ),
+				ISC_Model::MAX_POSTS
+			); ?>
+		</p>
+	<?php endif; ?>
 	<table class="widefat isc-table" style="width: 80%;" >
 		<thead>
 			<tr>
@@ -49,6 +58,15 @@ if ( ! empty( $attachments ) ) :
 	<h2><?php esc_html_e( 'Images with unknown position', 'image-source-control-isc' ); ?></h2>
 	<p><?php esc_html_e( 'The list contains images that neither have sources nor were yet found by ISC on your site.', 'image-source-control-isc' ); ?>&nbsp;
 	<?php esc_html_e( 'They might not need a source after all.', 'image-source-control-isc' ); ?></p>
+	<?php if( count( $attachments ) >= ISC_Model::MAX_POSTS ) : ?>
+		<p><?php
+			printf(
+			// translators: %d is the number of entries in the following table
+				esc_html__( 'The list only shows the last %d images.', 'image-source-control-isc' ),
+				ISC_Model::MAX_POSTS
+			); ?>
+		</p>
+	<?php endif; ?>
 	<table class="widefat isc-table" style="width: 80%;" >
 		<thead>
 			<tr>

--- a/includes/model.php
+++ b/includes/model.php
@@ -12,6 +12,11 @@ class ISC_Model {
 	protected static $instance;
 
 	/**
+	 * Maximum number of entries in custom queries
+	 */
+	const MAX_POSTS = 100;
+
+	/**
 	 * Setup registers filters and actions.
 	 */
 	public function __construct() {
@@ -421,7 +426,7 @@ class ISC_Model {
 	public static function get_attachments_with_empty_sources() {
 		$args = array(
 			'post_type'   => 'attachment',
-			'numberposts' => -1,
+			'numberposts' => self::MAX_POSTS,
 			'post_status' => null,
 			'post_parent' => null,
 			'meta_query'  => array(
@@ -453,7 +458,7 @@ class ISC_Model {
 	public static function get_unused_attachments() {
 		$args = array(
 			'post_type'   => 'attachment',
-			'numberposts' => -1,
+			'numberposts' => self::MAX_POSTS,
 			'post_status' => null,
 			'post_parent' => null,
 			'meta_query'  => array(

--- a/readme.txt
+++ b/readme.txt
@@ -123,6 +123,10 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 == Changelog ==
 
+= untagged =
+
+- Improvement: limit queries for missing sources to 100 to prevent the check from causing a timeout on sites with a lot of images
+
 = 2.10.0 =
 
 - Improvement: remove ISC fields from media frame when it is not loaded from the media library page to prevent confusions


### PR DESCRIPTION
ISC checks all existing images for missing sources. This caused timeouts on sites with a lot of images.

The change now just limits such queries to 100. Sites with more images would not benefit from longer lists anyway.