### PR TITLE
Update missing sources warning more often

### DIFF
--- a/isc.class.php
+++ b/isc.class.php
@@ -113,6 +113,23 @@ class ISC_Class {
 			add_action( 'updated_post_meta', array( $this, 'maybe_update_attachment_post_meta' ), 10, 3 );
 
 			/**
+			 * Register actions to update missing sources checks each time attachments’ post meta is added
+			 *
+			 * See the "added_post_meta" action hook
+			 */
+			add_action( 'added_post_meta', array( $this, 'maybe_update_attachment_post_meta' ), 10, 3 );
+
+			/**
+			 * Register actions to update missing sources when an attachment was added
+			 */
+			add_action( 'add_attachment', array( 'ISC_Model', 'update_missing_sources_transient' ) );
+
+			/**
+			 * Register an action to update missing sources when an attachment was deleted
+			 */
+			add_action( 'deleted_post', array( 'ISC_Model', 'update_missing_sources_transient' ) );
+
+			/**
 			 * Clear post-image index whenever the content of a post is updated
 			 * this could force reindexing the post after adding or removing image sources
 			 */

--- a/readme.txt
+++ b/readme.txt
@@ -127,6 +127,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 = untagged =
 
 - Feature: (Pro) multiple links in the source string
+- Improvement: update missing image sources warning when an images was uploaded or deleted
 
 = 2.11.0 =
 


### PR DESCRIPTION
The count for the missing image sources notice in the backend was only updated when the ISC post meta data changed. It is now also updated when an image was first uploaded to the media library, when the sources were first added, and when an image is removed.