### PR TITLE
Added background overlay options

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -535,10 +535,13 @@ class ISC_Admin extends ISC_Class {
 	 * Render option to define which images should show the overlay
 	 */
 	public function renderfield_overlay_included_images() {
-		$options                 = $this->get_isc_options();
-		$included_images         = ! empty( $options['overlay_included_images'] ) ? $options['overlay_included_images'] : '';
-		$included_images_options = $this->get_overlay_included_images_options();
+		$options                  = $this->get_isc_options();
+		$included_images          = ! empty( $options['overlay_included_images'] ) ? $options['overlay_included_images'] : '';
+		$included_images_options  = $this->get_overlay_included_images_options();
 		require_once ISCPATH . '/admin/templates/settings/overlay-included-images.php';
+		$checked_advanced_options = ! empty( $options['overlay_included_advanced'] ) && is_array( $options['overlay_included_advanced'] ) ? $options['overlay_included_advanced'] : array();
+		$advanced_options         = $this->get_overlay_advanced_included_images_options();
+		require_once ISCPATH . '/admin/templates/settings/overlay-advanced-included-images.php';
 	}
 
 	/**
@@ -841,6 +844,7 @@ class ISC_Admin extends ISC_Class {
 		}
 		$output['list_included_images']    = isset( $input['list_included_images'] ) ? esc_attr( $input['list_included_images'] ) : '';
 		$output['overlay_included_images'] = isset( $input['overlay_included_images'] ) ? esc_attr( $input['overlay_included_images'] ) : '';
+		$output['overlay_included_advanced'] = isset( $input['overlay_included_advanced'] ) && is_array( $input['overlay_included_advanced'] ) ? $input['overlay_included_advanced'] : array();
 		$output['global_list_included_images'] = isset( $input['global_list_included_images'] ) ? esc_attr( $input['global_list_included_images'] ) : '';
 
 		/**

--- a/admin/templates/settings/overlay-advanced-included-images.php
+++ b/admin/templates/settings/overlay-advanced-included-images.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Render the advanced included images option for captions
+ *
+ * @var array $checked_advanced_options selected options
+ * @var array $advanced_options available options.
+ */
+?>
+<h4><?php esc_html_e( 'Advanced Options', 'image-source-control-isc' ); ?></h4>
+<p class="description">
+	<?php esc_html_e( 'The following options help developers to load image sources in critical places. They might need additional code to work or for styling.', 'image-source-control-isc' ); ?>
+	<a href="<?php echo ISC_Admin::get_manual_url( 'overlay-advanced-options' ); ?>" target="_blank"><?php esc_html_e( 'Manual', 'image-source-control-isc' ); ?></a>
+</p>
+<div>
+	<?php
+	foreach ( $advanced_options as $_key => $_options ) :
+		$value  = $_options['value'] ?? '';
+		$is_pro = ! empty( $_options['is_pro'] );
+		?>
+		<label>
+			<input type="checkbox" name="isc_options[overlay_included_advanced][]" value="<?php echo esc_attr( $value ); ?>"
+				<?php checked( in_array( $value, $checked_advanced_options ) ); ?>
+				<?php echo $is_pro ? 'disabled="disabled" class="is-pro"' : ''; ?>
+			/>
+			<?php if ( $is_pro ) : echo ISC_Admin::get_pro_link( 'overlay-' . sanitize_title( $_options['label'] ) ); endif; ?>
+			<?php if ( isset( $_options['label'] ) ) :
+				echo wp_kses(
+					$_options['label'],
+					array(
+						'code' => array(),
+					)
+				);
+			endif;
+			  ?>
+		</label>
+			<?php
+			if ( isset( $_options['description'] ) ) :
+				?>
+		<p class="description">
+				<?php
+				echo wp_kses(
+					$_options['description'],
+					array(
+						'code' => array(),
+					)
+				);
+				?>
+		</p>
+				<?php
+			else :
+				?><br><?php
+			endif;
+			?>
+	<?php endforeach; ?>
+</div>

--- a/admin/templates/settings/overlay-included-images.php
+++ b/admin/templates/settings/overlay-included-images.php
@@ -4,13 +4,14 @@
  *
  * @var string|bool $included_images value of the "overlay_included_images" option.
  * @var array $included_images_options information about the available options.
+ * @var array $advanced_options information about advanced options.
  */
 ?>
 <p class="description"><?php esc_html_e( 'Choose which images should show a source overlay.', 'image-source-control-isc' ); ?></p>
 <div class="isc-settings-highlighted">
 	<?php
 	foreach ( $included_images_options as $_key => $_options ) :
-		$value  = isset( $_options['value'] ) ? $_options['value'] : '';
+		$value  = $_options['value'] ?? '';
 		$is_pro = ! empty( $_options['is_pro'] );
 		?>
 		<label>

--- a/isc.class.php
+++ b/isc.class.php
@@ -384,6 +384,43 @@ GFDL GNU Free Documentation License 1.3|https://www.gnu.org/licenses/fdl-1.3.htm
 		}
 
 		/**
+		 * Get the advanced options for images that get an overlay with the source
+		 * These will be checkboxes. One can enable multiple options at once.
+		 */
+		public function get_overlay_advanced_included_images_options() {
+			$options = array(
+				'inline_style_data'  => array(
+					'label'       => __( 'Load the overlay text for inline styles', 'image-source-control-isc' ),
+					'value'       => 'inline_style_data',
+					'is_pro' => true,
+				),
+				'inline_style_show' => array(
+					'label'       => __( 'Display the overlay within tags that use inline styles', 'image-source-control-isc' ),
+					'value'       => 'inline_style_show',
+					'is_pro'      => true,
+				),
+				'style_block_data'  => array(
+					'label'       => sprintf(
+						__( 'Load the overlay text for %s blocks', 'image-source-control-isc' ),
+						'<code>style</code>'
+					),
+					'value'       => 'style_block_data',
+					'is_pro' => true,
+				),
+				'style_block_show' => array(
+					'label'       => sprintf(
+						__( 'Display the overlay after %s blocks', 'image-source-control-isc' ),
+						'<code>style</code>'
+					),
+					'value'       => 'style_block_show',
+					'is_pro'      => true,
+				),
+			);
+
+			return apply_filters( 'isc_overlay_advanced_included_images_options', $options );
+		}
+
+		/**
 		 * Get the options for images that appear in the global list
 		 */
 		public function get_global_list_included_images_options() {

--- a/public/assets/js/captions.js
+++ b/public/assets/js/captions.js
@@ -61,29 +61,38 @@ function isc_update_captions_positions() {
  */
 function isc_update_caption_position( el ) {
 	var main_id = el.id;
+	var caption = el.querySelector( '.isc-source-text' );
+	if ( ! caption ) {
+		return;
+	}
 
 	// attachment ID. unused
 	var att_id = main_id.split( '_' )[2];
 
 	var att  = el.querySelector( 'img' );
-	var attw = att.width;
-	var atth = att.height;
+	var is_fallback = false;
+	// fall back to the current main container to get the width and height, if no image was found. This could be a background image defined in CSS
+	if ( ! att ) {
+		att = el;
+		is_fallback = true;
+	}
+	// look for the actual width and height as a fallback, if these attributes are not set
+	var attw = att instanceof HTMLImageElement ? att.width : att.offsetWidth;
+	var atth = att instanceof HTMLImageElement ? att.height : att.offsetHeight;
 
 	// relative position
-	var l = att.offsetLeft;
-	var t = att.offsetTop;
-
-	var caption = el.querySelector( '.isc-source-text' );
+	var l = ! is_fallback ? att.offsetLeft : 0;
+	var t = ! is_fallback ? att.offsetTop : 0;
 
 	// caption width + padding & margin (after moving onto image)
 	var tw = ISCouterWidth( caption );
 	// caption height + padding (idem)
 	var th = ISCouterHeight( caption );
 
-	var attpl = parseInt( window.getComputedStyle( att )[ 'padding-left' ].substring( 0, window.getComputedStyle( att )[ 'padding-left' ].indexOf( 'px' ) ) );
-	var attpt = parseInt( window.getComputedStyle( att )[ 'padding-top' ].substring( 0, window.getComputedStyle( att )[ 'padding-top' ].indexOf( 'px' ) ) );
-	var attml = parseInt( window.getComputedStyle( att )[ 'margin-left' ].substring( 0, window.getComputedStyle( att )[ 'margin-left' ].indexOf( 'px' ) ) );
-	var attmt = parseInt( window.getComputedStyle( att )[ 'margin-top' ].substring( 0, window.getComputedStyle( att )[ 'margin-top' ].indexOf( 'px' ) ) );
+	var attpl = ! is_fallback ? parseInt( window.getComputedStyle( att )[ 'padding-left' ].substring( 0, window.getComputedStyle( att )[ 'padding-left' ].indexOf( 'px' ) ) ) : 0;
+	var attpt = ! is_fallback ? parseInt( window.getComputedStyle( att )[ 'padding-top' ].substring( 0, window.getComputedStyle( att )[ 'padding-top' ].indexOf( 'px' ) ) ) : 0;
+	var attml = ! is_fallback ? parseInt( window.getComputedStyle( att )[ 'margin-left' ].substring( 0, window.getComputedStyle( att )[ 'margin-left' ].indexOf( 'px' ) ) ) : 0;
+	var attmt = ! is_fallback ? parseInt( window.getComputedStyle( att )[ 'margin-top' ].substring( 0, window.getComputedStyle( att )[ 'margin-top' ].indexOf( 'px' ) ) ) : 0;
 
 	// caption horizontal margin
 	var tml = 5;

--- a/public/public.php
+++ b/public/public.php
@@ -976,7 +976,6 @@ class ISC_Public extends ISC_Class {
 	 */
 	public function render_image_source_string( $id, $data = array() ) {
 		$id = esc_attr( $id );
-
 		$options = $this->get_isc_options();
 
 		$metadata['source']     = isset( $data['source'] ) ? $data['source'] : self::get_image_source_text( $id );
@@ -1031,6 +1030,33 @@ class ISC_Public extends ISC_Class {
 		}
 
 		return $source;
+	}
+
+	/**
+	 * Render caption string / markup
+	 * The string is not wrapped, e.g., in a <span> tag
+	 *
+	 * @param int $id   id of the image.
+	 * @param int $data metadata.
+	 *
+	 * @return string false if no source was given, else string with source
+	 */
+	public function render_caption_string( int $id, $data = array() ) {
+		$source_string = $this->render_image_source_string( $id, $data );
+
+		if ( ! $source_string ) {
+			ISC_Log::log( sprintf( 'render_caption_string() skipped overlay for empty sources string for ID "%s"', $id ) );
+			return '';
+		}
+
+		// don’t render the caption for own images if the admin choose not to do so
+		if ( self::is_standard_source( 'exclude' ) && ISC_Public::use_standard_source( $id ) ) {
+			ISC_Log::log( sprintf( 'render_caption_string() skipped overlay for "own" image ID "%s"', $id ) );
+			return '';
+		}
+
+		$options = $this->get_isc_options();
+		return ! empty( $options['source_pretext'] ) ? $options['source_pretext'] . ' ' . $source_string : $source_string;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -126,6 +126,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 = untagged =
 
+- Feature: find .webp images after they are now supported in the WordPress Media library as well
 - Feature: (Pro) set the `isc-disable-overlay` class on specific images to prevent the overlay from showing up
 - Feature: (Pro) Various options to load and show overlays for images in `style` attributes and `<style>` blocks.
 - Improvement: find alignment information classes also, when multiple classes are given in the `<figure>` tag

--- a/readme.txt
+++ b/readme.txt
@@ -127,8 +127,10 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 = untagged =
 
 - Feature: (Pro) set the `isc-disable-overlay` class on specific images to prevent the overlay from showing up
+- Feature: (Pro) Various options to load and show overlays for images in `style` attributes and `<style>` blocks.
 - Improvement: find alignment information classes also, when multiple classes are given in the `<figure>` tag
 - Improvement: added the `isc_extract_images_from_html` filter to manipulate images that use captions
+- Improvement: The `ISC_Public->render_caption_string()` function renders the overlay string
 - Fix: the page content was not put together correctly when `isc_stop_overlay` was added manually to it and no images were found
 
 = 2.12.0 =


### PR DESCRIPTION
Added advanced options to support source overlays on images in `style` attributes in tags, e.g., CSS background images, and in `style` tags. The code for these features is in Pro.

Added `render_caption_string()` to render the overlay string.