### PR TITLE
Improve caption search

### DIFF
--- a/includes/model.php
+++ b/includes/model.php
@@ -739,12 +739,12 @@ class ISC_Model {
 		 * 1 - <figure> if set and having a class attribute
 		 * 2 – classes from figure tag
 		 * 3 – inner code starting with <a>
-		 * 4 – opening link attribute
+		 * 4 – opening link tag
 		 * 5 – "rel" attribute from link tag
 		 * 6 – image id from link wp-att- value in "rel" attribute
 		 * 7 – full img tag
 		 * 8 – image URL
-		 * 9 – (unused)
+		 * 9 – closing link tag
 		 *
 		 * tested with:
 		 * * with and without [caption]

--- a/includes/model.php
+++ b/includes/model.php
@@ -758,6 +758,9 @@ class ISC_Model {
 		$pattern = '#(<figure[^>]*class="([^"]*)"[^>]*>)?((<a[\x20|\x9|\xD|\xA]+[^>]*(rel="[^"]*[^"]*wp-att-(\d+)"[^>]*)*>)?\s*(<img[\x20|\x9|\xD|\xA]+[^>]*[^>]*src="(.+)".*\/?>).*(\s*</a>)??[^<]*)#isU';
 		preg_match_all( $pattern, apply_filters( 'isc_public_caption_regex_content', $html ), $matches, PREG_SET_ORDER );
 
-		return $matches;
+		/**
+		 * Filter matches from regex
+		 */
+		return apply_filters( 'isc_extract_images_from_html', $matches );
 	}
 }

--- a/includes/model.php
+++ b/includes/model.php
@@ -723,4 +723,41 @@ class ISC_Model {
 
 		update_post_meta( $post_id, $key, $value );
 	}
+
+	/**
+	 * Extract image-related markup from larger chunks of HTML.
+	 *
+	 * @param string $html HTML to extract images from.
+	 * @return array Array of image markup.
+	 */
+	public static function extract_images_from_html( string $html ) : array {
+		/**
+		 * Removed [caption], because this check runs after the hook that interprets shortcodes
+		 * img tag is checked individually since there is a different order of attributes when images are used in gallery or individually
+		 *
+		 * 0 – full match
+		 * 1 - <figure> if set and having a class attribute
+		 * 2 – classes from figure tag
+		 * 3 – inner code starting with <a>
+		 * 4 – opening link attribute
+		 * 5 – "rel" attribute from link tag
+		 * 6 – image id from link wp-att- value in "rel" attribute
+		 * 7 – full img tag
+		 * 8 – image URL
+		 * 9 – (unused)
+		 *
+		 * tested with:
+		 * * with and without [caption]
+		 * * with and without link attribute
+		 *
+		 * potential issues:
+		 * * line breaks in the code – use \s* where potential line breaks could appear
+		 *
+		 * Use (\x20|\x9|\xD|\xA)+ to match whitespace following HTML starting tag name according to W3C REC 3.1. See issue PR #136
+		 */
+		$pattern = '#(<figure[^>]*class="([^"]*)"[^>]*>)?((<a[\x20|\x9|\xD|\xA]+[^>]*(rel="[^"]*[^"]*wp-att-(\d+)"[^>]*)*>)?\s*(<img[\x20|\x9|\xD|\xA]+[^>]*[^>]*src="(.+)".*\/?>).*(\s*</a>)??[^<]*)#isU';
+		preg_match_all( $pattern, apply_filters( 'isc_public_caption_regex_content', $html ), $matches, PREG_SET_ORDER );
+
+		return $matches;
+	}
 }

--- a/public/public.php
+++ b/public/public.php
@@ -255,37 +255,11 @@ class ISC_Public extends ISC_Class {
 			$content_after = '';
 		}
 
-		/**
-		 * Removed [caption], because this check runs after the hook that interprets shortcodes
-		 * img tag is checked individually since there is a different order of attributes when images are used in gallery or individually
-		 *
-		 * 0 – full match
-		 * 1 - <figure> if set and having a class attribute
-		 * 2 – classes from figure tag
-		 * 3 – inner code starting with <a>
-		 * 4 – opening link attribute
-		 * 5 – "rel" attribute from link tag
-		 * 6 – image id from link wp-att- value in "rel" attribute
-		 * 7 – full img tag
-		 * 8 – image URL
-		 * 9 – (unused)
-		 *
-		 * tested with:
-		 * * with and without [caption]
-		 * * with and without link attribute
-		 *
-		 * potential issues:
-		 * * line breaks in the code – use \s* where potential line breaks could appear
-		 *
-		 * Use (\x20|\x9|\xD|\xA)+ to match whitespace following HTML starting tag name according to W3C REC 3.1. See issue PR #136
-		 */
-		$pattern = '#(<figure[^>]*class="([^"]*)"[^>]*>)?((<a[\x20|\x9|\xD|\xA]+[^>]*(rel="[^"]*[^"]*wp-att-(\d+)"[^>]*)*>)?\s*(<img[\x20|\x9|\xD|\xA]+[^>]*[^>]*src="(.+)".*\/?>).*(\s*</a>)??[^<]*)#isU';
-		$content = apply_filters( 'isc_public_caption_regex_content', $content );
-		$count   = preg_match_all( $pattern, $content, $matches, PREG_SET_ORDER );
+		$matches = ISC_Model::extract_images_from_html( $content );
 
-		ISC_Log::log( 'embedded images found: ' . $count );
+		ISC_Log::log( 'embedded images found: ' . count( $matches ) );
 
-		if ( false === $count ) {
+		if ( ! count( $matches ) ) {
 			return $content;
 		}
 

--- a/public/public.php
+++ b/public/public.php
@@ -260,8 +260,8 @@ class ISC_Public extends ISC_Class {
 		 * img tag is checked individually since there is a different order of attributes when images are used in gallery or individually
 		 *
 		 * 0 – full match
-		 * 1 - <figure> if set
-		 * 2 – alignment
+		 * 1 - <figure> if set and having a class attribute
+		 * 2 – classes from figure tag
 		 * 3 – inner code starting with <a>
 		 * 4 – opening link attribute
 		 * 5 – "rel" attribute from link tag
@@ -269,7 +269,6 @@ class ISC_Public extends ISC_Class {
 		 * 7 – full img tag
 		 * 8 – image URL
 		 * 9 – (unused)
-		 * 10 - </figure>
 		 *
 		 * tested with:
 		 * * with and without [caption]
@@ -280,7 +279,7 @@ class ISC_Public extends ISC_Class {
 		 *
 		 * Use (\x20|\x9|\xD|\xA)+ to match whitespace following HTML starting tag name according to W3C REC 3.1. See issue PR #136
 		 */
-		$pattern = '#(<[^>]*class="[^"]*(alignleft|alignright|alignnone|aligncenter).*)?((<a[\x20|\x9|\xD|\xA]+[^>]*(rel="[^"]*[^"]*wp-att-(\d+)"[^>]*)*>)?\s*(<img[\x20|\x9|\xD|\xA]+[^>]*[^>]*src="(.+)".*\/?>).*(\s*</a>)??[^<]*).*(<\/figure.*>)?#isU';
+		$pattern = '#(<figure[^>]*class="([^"]*)"[^>]*>)?((<a[\x20|\x9|\xD|\xA]+[^>]*(rel="[^"]*[^"]*wp-att-(\d+)"[^>]*)*>)?\s*(<img[\x20|\x9|\xD|\xA]+[^>]*[^>]*src="(.+)".*\/?>).*(\s*</a>)??[^<]*)#isU';
 		$content = apply_filters( 'isc_public_caption_regex_content', $content );
 		$count   = preg_match_all( $pattern, $content, $matches, PREG_SET_ORDER );
 

--- a/readme.txt
+++ b/readme.txt
@@ -124,6 +124,12 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 == Changelog ==
 
+= untagged =
+
+- Feature: (Pro) set the `isc-disable-overlay` class on specific images to prevent the overlay from showing up
+- Improvement: find alignment information classes also, when multiple classes are given in the `<figure>` tag
+- Improvement: added the `isc_extract_images_from_html` filter to manipulate images that use captions
+
 = 2.12.0 =
 
 - Feature: (Pro) link different terms in the source string to different URLs

--- a/tests/wpunit/model/Extract_Images_From_Html_Test.php
+++ b/tests/wpunit/model/Extract_Images_From_Html_Test.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace ISC\Tests\WPUnit;
+
+use \ISC_Model;
+
+/**
+ * Test if ISC_Model::extract_images_from_html() works as expected.
+ */
+class Extract_Images_From_Html_Test extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * Test if the function returns an array
+	 * Whatever is entered, it is always an array
+	 */
+	public function test_array() {
+		$html = 'some random string';
+		$result = ISC_Model::extract_images_from_html( $html );
+		$this->assertIsArray( $result, "extract_images_from_html did not return an array" );
+	}
+
+	/**
+	 * Extract information from a simple image tag
+	 * - 0 full HTML
+	 * - 3 img tag
+	 * - 8 image URL
+	 */
+	public function test_extract_image() {
+		$html = '<img src="https://example.com/test.jpg">';
+		$expected = [
+			[
+				0 => '<img src="https://example.com/test.jpg">',
+				1 => '',
+				2 => '',
+				3 => '<img src="https://example.com/test.jpg">',
+				4 => '',
+				5 => '',
+				6 => '',
+				7 => '<img src="https://example.com/test.jpg">',
+				8 => 'https://example.com/test.jpg',
+			]
+		];
+		$result = ISC_Model::extract_images_from_html( $html );
+		//fwrite( STDERR, print_r( $result, TRUE ) );
+		$this->assertEquals($expected, $result, "extract_images_from_html did not return the correct image information");
+	}
+
+	/**
+	 * Test image src URL not having a file extension
+	 */
+	public function test_image_src_without_extension() {
+		$html = '<img src="https://example.com/test">';
+		$expected = [
+			[
+				0 => '<img src="https://example.com/test">',
+				1 => '',
+				2 => '',
+				3 => '<img src="https://example.com/test">',
+				4 => '',
+				5 => '',
+				6 => '',
+				7 => '<img src="https://example.com/test">',
+				8 => 'https://example.com/test',
+			]
+		];
+		$result = ISC_Model::extract_images_from_html( $html );
+		$this->assertEquals( $expected, $result, "extract_images_from_html did not return the correct image information" );
+	}
+
+	/**
+	 * Extract information from an image wrapped in a link
+	 */
+	public function test_extract_image_in_link() {
+		$html = '<a href="https://example.com"><img src="https://example.com/test.jpg"></a>';
+		$expected = [
+			[
+				0 => '<a href="https://example.com"><img src="https://example.com/test.jpg"></a>',
+				1 => '',
+				2 => '',
+				3 => '<a href="https://example.com"><img src="https://example.com/test.jpg"></a>',
+				4 => '<a href="https://example.com">',
+				5 => '',
+				6 => '',
+				7 => '<img src="https://example.com/test.jpg">',
+				8 => 'https://example.com/test.jpg',
+				9 => '</a>'
+			]
+		];
+		$result = ISC_Model::extract_images_from_html( $html );
+		$this->assertEquals( $expected, $result, "extract_images_from_html did not return the correct image information" );
+	}
+
+	/**
+	 * Extract information from an image wrapped in a figure tag without classes
+	 * <figure> is ignored since it doesn’t have any classes
+	 */
+	public function test_extract_image_in_figure_without_classes() {
+		$html = '<figure><img src="https://example.com/test.jpg"></figure>';
+		$expected = [
+			[
+				0 => '<img src="https://example.com/test.jpg">',
+				1 => '',
+				2 => '',
+				3 => '<img src="https://example.com/test.jpg">',
+				4 => '',
+				5 => '',
+				6 => '',
+				7 => '<img src="https://example.com/test.jpg">',
+				8 => 'https://example.com/test.jpg'
+			]
+		];
+		$result = ISC_Model::extract_images_from_html( $html );
+		$this->assertEquals( $expected, $result, "extract_images_from_html did not return the correct image information" );
+	}
+
+	/**
+	 * Extract information from an image wrapped in a figure tag with classes
+	 */
+	public function test_extract_image_in_figure_with_classes() {
+		$html = '<figure class="wp-block-image"><img src="https://example.com/test.jpg"></figure>';
+		$expected = [
+			[
+				0 => '<figure class="wp-block-image"><img src="https://example.com/test.jpg">',
+				1 => '<figure class="wp-block-image">',
+				2 => 'wp-block-image',
+				3 => '<img src="https://example.com/test.jpg">',
+				4 => '',
+				5 => '',
+				6 => '',
+				7 => '<img src="https://example.com/test.jpg">',
+				8 => 'https://example.com/test.jpg'
+			]
+		];
+		$result = ISC_Model::extract_images_from_html( $html );
+		$this->assertEquals( $expected, $result, "extract_images_from_html did not return the correct image information" );
+	}
+
+	/**
+	 * Extract information from image wrapped in a figure tag with classes and a link
+	 */
+	public function test_extract_image_in_figure_with_classes_and_link() {
+		$html = '<figure class="wp-block-image isc-disable-overlay"><a href="https://example.com"><img src="https://example.com/test.jpg"></a></figure>';
+		$expected = [
+			[
+				0 => '<figure class="wp-block-image isc-disable-overlay"><a href="https://example.com"><img src="https://example.com/test.jpg"></a>',
+				1 => '<figure class="wp-block-image isc-disable-overlay">',
+				2 => 'wp-block-image isc-disable-overlay',
+				3 => '<a href="https://example.com"><img src="https://example.com/test.jpg"></a>',
+				4 => '<a href="https://example.com">',
+				5 => '',
+				6 => '',
+				7 => '<img src="https://example.com/test.jpg">',
+				8 => 'https://example.com/test.jpg',
+				9 => '</a>'
+			]
+		];
+		$result = ISC_Model::extract_images_from_html( $html );
+		$this->assertEquals( $expected, $result, "extract_images_from_html did not return the correct image information" );
+	}
+
+	/**
+	 * Test real HTML from Classic Editor
+	 */
+	public function test_extract_image_from_classic_editor() {
+		$html = '<p><img decoding="async" loading="lazy" class="alignnone size-medium wp-image-6315" src="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg" alt="" width="300" height="179" srcset="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg 300w, http://example.com/wp-content/uploads/2023/04/logo.jpeg 512w" sizes="(max-width: 300px) 100vw, 300px" /></p>';
+		$expected = [
+			[
+				0 => '<img decoding="async" loading="lazy" class="alignnone size-medium wp-image-6315" src="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg" alt="" width="300" height="179" srcset="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg 300w, http://example.com/wp-content/uploads/2023/04/logo.jpeg 512w" sizes="(max-width: 300px) 100vw, 300px" />',
+				1 => '',
+				2 => '',
+				3 => '<img decoding="async" loading="lazy" class="alignnone size-medium wp-image-6315" src="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg" alt="" width="300" height="179" srcset="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg 300w, http://example.com/wp-content/uploads/2023/04/logo.jpeg 512w" sizes="(max-width: 300px) 100vw, 300px" />',
+				4 => '',
+				5 => '',
+				6 => '',
+				7 => '<img decoding="async" loading="lazy" class="alignnone size-medium wp-image-6315" src="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg" alt="" width="300" height="179" srcset="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg 300w, http://example.com/wp-content/uploads/2023/04/logo.jpeg 512w" sizes="(max-width: 300px) 100vw, 300px" />',
+				8 => 'http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg'
+			]
+		];
+		$result = ISC_Model::extract_images_from_html( $html );
+		$this->assertEquals( $expected, $result, "extract_images_from_html did not return the correct image information" );
+	}
+
+	/**
+	 * Test real HTML from Block Editor
+	 */
+	public function test_extract_image_from_block_editor() {
+		$html = '<figure class="wp-block-image aligncenter size-full is-style-default isc_disable_overlay"><a href="http://example.com/wp-content/uploads/2023/04/logo.jpeg"><img decoding="async" width="512" height="306" src="http://example.com/wp-content/uploads/2023/04/logo.jpeg" alt="" class="wp-image-6315" srcset="http://example.com/wp-content/uploads/2023/04/logo.jpeg 512w, http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg 300w" sizes="(max-width: 512px) 100vw, 512px" /></a></figure>';
+		$expected = [
+			[
+				0 => '<figure class="wp-block-image aligncenter size-full is-style-default isc_disable_overlay"><a href="http://example.com/wp-content/uploads/2023/04/logo.jpeg"><img decoding="async" width="512" height="306" src="http://example.com/wp-content/uploads/2023/04/logo.jpeg" alt="" class="wp-image-6315" srcset="http://example.com/wp-content/uploads/2023/04/logo.jpeg 512w, http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg 300w" sizes="(max-width: 512px) 100vw, 512px" /></a>',
+				1 => '<figure class="wp-block-image aligncenter size-full is-style-default isc_disable_overlay">',
+				2 => 'wp-block-image aligncenter size-full is-style-default isc_disable_overlay',
+				3 => '<a href="http://example.com/wp-content/uploads/2023/04/logo.jpeg"><img decoding="async" width="512" height="306" src="http://example.com/wp-content/uploads/2023/04/logo.jpeg" alt="" class="wp-image-6315" srcset="http://example.com/wp-content/uploads/2023/04/logo.jpeg 512w, http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg 300w" sizes="(max-width: 512px) 100vw, 512px" /></a>',
+				4 => '<a href="http://example.com/wp-content/uploads/2023/04/logo.jpeg">',
+				5 => '',
+				6 => '',
+				7 => '<img decoding="async" width="512" height="306" src="http://example.com/wp-content/uploads/2023/04/logo.jpeg" alt="" class="wp-image-6315" srcset="http://example.com/wp-content/uploads/2023/04/logo.jpeg 512w, http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg 300w" sizes="(max-width: 512px) 100vw, 512px" />',
+				8 => 'http://example.com/wp-content/uploads/2023/04/logo.jpeg',
+				9 => '</a>'
+			]
+		];
+		$result = ISC_Model::extract_images_from_html( $html );
+		$this->assertEquals( $expected, $result, "extract_images_from_html did not return the correct image information" );
+	}
+
+	/**
+	 * Test with line breaks and spaces
+	 */
+	public function DISABLED_test_extract_image_with_line_breaks_and_spaces() {
+		$html = '<figure class="wp-block-image isc-disable-overlay">
+			<a href="https://example.com">
+				<img src="https://example.com/test.jpg">
+			</a>
+		</figure>';
+		$expected = [
+			[
+				0 => '<figure class="wp-block-image isc-disable-overlay">
+			<a href="https://example.com">
+				<img src="https://example.com/test.jpg">
+			</a>',
+				1 => '<figure class="wp-block-image isc-disable-overlay">',
+				2 => 'wp-block-image isc-disable-overlay',
+				3 => '<a href="https://example.com">
+				<img src="https://example.com/test.jpg">
+			</a>',
+				4 => '<a href="https://example.com">',
+				5 => '',
+				6 => '',
+				7 => '<img src="https://example.com/test.jpg">',
+				8 => 'https://example.com/test.jpg',
+				9 => '</a>'
+			]
+		];
+		$result = ISC_Model::extract_images_from_html( $html );
+		$this->assertEquals( $expected, $result, "extract_images_from_html did not return the correct image information" );
+	}
+}
+

--- a/tests/wpunit/model/Extract_Images_From_Html_Test.php
+++ b/tests/wpunit/model/Extract_Images_From_Html_Test.php
@@ -204,6 +204,40 @@ class Extract_Images_From_Html_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * Find multiple images in HTML
+	 */
+	public function test_extract_multiple_images() {
+		$html = '<figure class="wp-block-image"><img decoding="async" width="267" height="200" class="wp-image-177" src="http://example.com/wp-content/uploads/2020/11/400x300-267x200.png" alt="" srcset="http://example.com/wp-content/uploads/2020/11/400x300-267x200.png 267w, http://example.com/wp-content/uploads/2020/11/400x300.png 400w" sizes="(max-width: 267px) 100vw, 267px" /></figure>
+<p><img decoding="async" loading="lazy" class="alignnone size-medium wp-image-6315" src="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg" alt="" width="300" height="179" srcset="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg 300w, http://example.com/wp-content/uploads/2023/04/logo.jpeg 512w" sizes="(max-width: 300px) 100vw, 300px" /></p>';
+		$expected = [
+			[
+				0 => '<figure class="wp-block-image"><img decoding="async" width="267" height="200" class="wp-image-177" src="http://example.com/wp-content/uploads/2020/11/400x300-267x200.png" alt="" srcset="http://example.com/wp-content/uploads/2020/11/400x300-267x200.png 267w, http://example.com/wp-content/uploads/2020/11/400x300.png 400w" sizes="(max-width: 267px) 100vw, 267px" />',
+				1 => '<figure class="wp-block-image">',
+				2 => 'wp-block-image',
+				3 => '<img decoding="async" width="267" height="200" class="wp-image-177" src="http://example.com/wp-content/uploads/2020/11/400x300-267x200.png" alt="" srcset="http://example.com/wp-content/uploads/2020/11/400x300-267x200.png 267w, http://example.com/wp-content/uploads/2020/11/400x300.png 400w" sizes="(max-width: 267px) 100vw, 267px" />',
+				4 => '',
+				5 => '',
+				6 => '',
+				7 => '<img decoding="async" width="267" height="200" class="wp-image-177" src="http://example.com/wp-content/uploads/2020/11/400x300-267x200.png" alt="" srcset="http://example.com/wp-content/uploads/2020/11/400x300-267x200.png 267w, http://example.com/wp-content/uploads/2020/11/400x300.png 400w" sizes="(max-width: 267px) 100vw, 267px" />',
+				8 => 'http://example.com/wp-content/uploads/2020/11/400x300-267x200.png'
+			],
+			[
+				0 => '<img decoding="async" loading="lazy" class="alignnone size-medium wp-image-6315" src="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg" alt="" width="300" height="179" srcset="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg 300w, http://example.com/wp-content/uploads/2023/04/logo.jpeg 512w" sizes="(max-width: 300px) 100vw, 300px" />',
+				1 => '',
+				2 => '',
+				3 => '<img decoding="async" loading="lazy" class="alignnone size-medium wp-image-6315" src="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg" alt="" width="300" height="179" srcset="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg 300w, http://example.com/wp-content/uploads/2023/04/logo.jpeg 512w" sizes="(max-width: 300px) 100vw, 300px" />',
+				4 => '',
+				5 => '',
+				6 => '',
+				7 => '<img decoding="async" loading="lazy" class="alignnone size-medium wp-image-6315" src="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg" alt="" width="300" height="179" srcset="http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg 300w, http://example.com/wp-content/uploads/2023/04/logo.jpeg 512w" sizes="(max-width: 300px) 100vw, 300px" />',
+				8 => 'http://example.com/wp-content/uploads/2023/04/logo-300x179.jpeg'
+			]
+		];
+		$result = ISC_Model::extract_images_from_html( $html );
+		$this->assertEquals( $expected, $result, "extract_images_from_html did not return the correct image information" );
+	}
+
+	/**
 	 * Test with line breaks and spaces
 	 */
 	public function DISABLED_test_extract_image_with_line_breaks_and_spaces() {


### PR DESCRIPTION
Improve search for images in HTML to place the caption.

- moved the search for images in HTML to a new function in ISC_Model for simpler testing
- added the `isc_extract_images_from_html` hook to allow filtering the results
- ignore closing `</figure>` tags since we don’t use them
- find all classes in the `<figure>` tag, not just the predefined ones
- added WP Unit tests to cover various source HTMLs to find images