### PR TITLE
Fix content split when using isc_stop_overlay

### DIFF
--- a/public/public.php
+++ b/public/public.php
@@ -261,7 +261,7 @@ class ISC_Public extends ISC_Class {
 		ISC_Log::log( 'embedded images found: ' . count( $matches ) );
 
 		if ( ! count( $matches ) ) {
-			return $content;
+			return $content . $content_after;
 		}
 
 		$options          = $this->get_isc_options();

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 - Feature: (Pro) set the `isc-disable-overlay` class on specific images to prevent the overlay from showing up
 - Improvement: find alignment information classes also, when multiple classes are given in the `<figure>` tag
 - Improvement: added the `isc_extract_images_from_html` filter to manipulate images that use captions
+- Fix: the page content was not put together correctly when `isc_stop_overlay` was added manually to it and no images were found
 
 = 2.12.0 =
 

--- a/tests/wpunit/public/Stop_Overlay_Test.php
+++ b/tests/wpunit/public/Stop_Overlay_Test.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ISC\Tests\WPUnit;
+
+use \ISC_Public;
+
+/**
+ * Test if ISC_Public::add_source_captions_to_content() splits the content correctly when `isc_stop_overlay` exists
+ */
+class Stop_Overlay_Test extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * @var ISC_Public
+	 */
+	protected $isc_public;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->isc_public = new ISC_Public();
+	}
+
+	/**
+	 * Test if ISC_Public::add_source_captions_to_content() splits the content correctly when `isc_stop_overlay` exists
+	 * No image given in the HTML
+	 */
+	public function test_split_content_without_image() {
+		$html     = '<p>Some text</p><div class="isc_stop_overlay"></div><p>Some more text</p>';
+		$expected = '<p>Some text</p><div class=""></div><p>Some more text</p>';
+		$result   = ISC_Public::get_instance()->add_source_captions_to_content( $html );
+		$this->assertEquals( $expected, $result, 'Content with isc_stop_overlay but without images was not combined correctly' );
+	}
+
+	/**
+	 * Test if ISC_Public::add_source_captions_to_content() splits the content correctly when `isc_stop_overlay` exists
+	 * One image given in the HTML
+	 */
+	public function test_split_content_with_image() {
+		$html     = '<p>Some text</p><img src="https://example.com/image.jpg" alt="Image" /><div class="isc_stop_overlay"></div><p>Some more text</p>';
+		$expected = '<p>Some text</p><img src="https://example.com/image.jpg" alt="Image" /><div class=""></div><p>Some more text</p>';
+		$result   = ISC_Public::get_instance()->add_source_captions_to_content( $html );
+		$this->assertEquals( $expected, $result, 'Content with isc_stop_overlay and one image was not combined correctly' );
+	}
+}


### PR DESCRIPTION
The page content was not put back together correctly, when `isc_stop_overlay` was added to it to stop overlay output and no images appeared in the first part.