### PR TITLE
Replaced usage of media.php

### DIFF
--- a/admin/templates/image-posts-list.php
+++ b/admin/templates/image-posts-list.php
@@ -20,7 +20,9 @@ if ( $images_with_posts->have_posts() ) : ?>
 			if ( is_array( $_posts ) && count( $_posts ) > 0 ) :
 				?>
 		<tr>
-			<td><a href="<?php echo esc_url( admin_url( 'media.php?attachment_id=' . get_the_ID() . '&action=edit' ) ); ?>"><?php the_title(); ?></a></td>
+			<td>
+				<?php edit_post_link( get_the_title(), '', '', get_the_ID() ); ?>
+			</td>
 			<td>
 					<ul>
 					<?php

--- a/admin/templates/post-images-list.php
+++ b/admin/templates/post-images-list.php
@@ -27,7 +27,8 @@ if ( $posts_with_images->have_posts() ) : ?>
 					foreach ( $_images as $_image_id => $_image_url ) :
 						?>
 						<li><?php if ( $_image_id ) : ?>
-							<a href="<?php echo esc_url( admin_url( 'media.php?attachment_id=' . $_image_id . '&action=edit' ) ); ?>" title="<?php esc_html_e( 'edit this image', 'image-source-control-isc' ); ?>"><?php echo esc_html( get_the_title( $_image_id ) ); ?></a></li>
+							<?php edit_post_link( esc_html( get_the_title( $_image_id ) ), '', '', $_image_id ); ?>
+						</li>
 						<?php else : ?>
 							<?php print_r( $_images ); ?>
 						<?php endif; ?>

--- a/admin/templates/sources.php
+++ b/admin/templates/sources.php
@@ -32,7 +32,7 @@ if ( ! empty( $attachments ) ) :
 			?>
 		<tr>
 			<td><?php echo absint( $_attachment->ID ); ?></td>
-			<td><a href="<?php echo esc_url( admin_url( 'media.php?attachment_id=' . $_attachment->ID . '&action=edit' ) ); ?>" title="<?php esc_html_e( 'edit this image', 'image-source-control-isc' ); ?>"><?php echo esc_html( $_attachment->post_title ); ?></a></td>
+			<td><?php edit_post_link( esc_html( $_attachment->post_title ), '', '', $_attachment->ID ); ?></td>
 			<td>
 			<?php
 			if ( $_attachment->post_parent ) :
@@ -79,7 +79,7 @@ if ( ! empty( $attachments ) ) :
 			?>
 		<tr>
 			<td><?php echo absint( $_attachment->ID ); ?></td>
-			<td><a href="<?php echo esc_url( admin_url( 'media.php?attachment_id=' . $_attachment->ID . '&action=edit' ) ); ?>" title="<?php esc_html_e( 'edit this image', 'image-source-control-isc' ); ?>"><?php echo esc_html( $_attachment->post_title ); ?></a></td>
+			<td><?php edit_post_link( esc_html( $_attachment->post_title ), '', '', $_attachment->ID ); ?></td>
 		</tr>
 		<?php endforeach; ?>
 	</tbody></table>

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 - Feature: Added "CC BY-SA 2.0 DE" to available licenses
 - Improvement: The overview position option became more visual and shows a preview of the choice when changed
 - Improvement: Hide the position option, when the option to disable frontend markup is checked
+- Improvement: Replace usage of media.php for compatibility with WordPress 6.3
 
 = 2.13.0 =
 


### PR DESCRIPTION
The usage of `wp-admin/media.php` is deprecated with WordPress 6.3. It lead to an incorrect edit page anyway. The proper link target is the post edit page.