### PR TITLE
Improve preview

### DIFF
--- a/admin/assets/js/settings.js
+++ b/admin/assets/js/settings.js
@@ -20,9 +20,15 @@ jQuery( document ).ready(
 			$(this).addClass('selected');
 			$('#isc-settings-caption-position').val($(this).data('position'));
 
-			var newURL = isc_settings.baseurl + 'admin/templates/settings/preview/caption-preview.html' + "?path=" + encodeURIComponent( isc_settings.baseurl ) + "&caption_position=" + $(this).data('position');
-			$('#isc-settings-caption-preview iframe').attr('src', newURL);
-			$('#isc-settings-caption-preview').removeClass('hidden');
+			var iframe = document.createElement('iframe');
+			iframe.src = isc_settings.baseurl + 'admin/templates/settings/preview/caption-preview.html' + "?path=" + encodeURIComponent( isc_settings.baseurl ) + "&position=" + $(this).data('position') + "&pretext=" + encodeURIComponent( $('#source-pretext').val() );
+			iframe.width = "250";
+			iframe.height = "181";
+
+			var preview_container = $('#isc-settings-caption-preview');
+			preview_container.find('iframe').remove();
+			preview_container.append(iframe);
+			preview_container.removeClass('hidden');
 		});
 
 		// Hide the preview when the mouse leaves the option area or a click occurs outside the option area

--- a/admin/templates/settings/overlay-position.php
+++ b/admin/templates/settings/overlay-position.php
@@ -18,7 +18,5 @@
 	</div>
 	<input type="hidden" name="isc_options[caption_position]" id="isc-settings-caption-position" value="<?php echo esc_attr( $options['caption_position'] ); ?>">
 
-	<div id="isc-settings-caption-preview" class="hidden">
-		<iframe src="<?php echo ISCBASEURL . 'admin/templates/settings/preview/caption-preview.html'; ?>?path=<?php echo urlencode( ISCBASEURL ); ?>&caption_position=<?php echo urlencode( $options['caption_position'] ); ?>" width="250" height="181"></iframe>
-	</div>
+	<div id="isc-settings-caption-preview" class="hidden"></div>
 </div>

--- a/admin/templates/settings/overlay-text.php
+++ b/admin/templates/settings/overlay-text.php
@@ -6,4 +6,3 @@
  */
 ?>
 <input type="text" id='source-pretext' name="isc_options[source_pretext]" value="<?php echo esc_attr( $options['source_pretext'] ); ?>" />
-<p class="description"><?php esc_html_e( 'The text preceding the source.', 'image-source-control-isc' ); ?></p>

--- a/admin/templates/settings/preview/caption-preview.html
+++ b/admin/templates/settings/preview/caption-preview.html
@@ -4,7 +4,8 @@
 	<script>
 		// Parse the caption_position from the GET parameters.
 		var urlParams = new URLSearchParams(window.location.search);
-		var caption_position = urlParams.get('caption_position');
+		var caption_position = urlParams.get('position');
+		var caption_pretext = urlParams.get('pretext');
 
 		// Create the isc_front_data object.
 		var isc_front_data =
@@ -44,10 +45,11 @@
 <body>
 <div class="isc-source">
 	<img id="preview_image" src="">
-	<span class="isc-source-text">© Source</span>
+	<span class="isc-source-text"></span>
 </div>
 <script>
 	document.getElementById('preview_image').src = path + 'admin/templates/settings/preview/image-for-position-preview.jpg';
+	document.querySelector('.isc-source-text').innerHTML = caption_pretext + '@ Source';
 </script>
 </body>
 </html>


### PR DESCRIPTION
- don’t load the preview iframe on the page load, since it is hidden anyway
- show the source pretext in the preview
- remove irrelevant description for the pretext option