### PR TITLE
Prevent database queries for files with invalid file extension

### DIFF
--- a/includes/model.php
+++ b/includes/model.php
@@ -594,9 +594,9 @@ class ISC_Model {
 	}
 
 	/**
-	 * Get image ID by url accessing the database directly
+	 * Get image ID by URL accessing the database directly
 	 *
-	 * @param string $url url of the image.
+	 * @param string $url URL of the image.
 	 *
 	 * @return integer ID of the image.
 	 */
@@ -618,7 +618,12 @@ class ISC_Model {
 			} else {
 				return 0;
 			}
+		} elseif ( ! in_array( $ext, ISC_Class::get_instance()->allowed_extensions, true ) ) {
+			// a valid image extension is required, if an extension is given
+			ISC_Log::log( 'exit get_image_by_url() due to invalid image extension' );
+			return 0;
 		}
+
 		/**
 		 * Check for the format 'image-title-(e12452112-)300x200.jpg(?query…)' and removes
 		 * - the image size

--- a/readme.txt
+++ b/readme.txt
@@ -124,6 +124,10 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 == Changelog ==
 
+= untagged =
+
+- Dev: Prevent unnecessary database queries when an image has an invalid file extension
+
 = 2.14.1 =
 
 - Fix: PHP error on the first load of a page with an image that is not part of the media library


### PR DESCRIPTION
We already covered the case that an image without an extension could be handled. We missed the case of files with invalid extensions though, that in some cases, could be in the `src` or `url()` attributes. This is handled now.