### PR TITLE
Unused images

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -487,8 +487,16 @@ class ISC_Admin extends ISC_Class {
 			$attachments = ISC_Model::get_unused_attachments();
 			if ( ! empty( $attachments ) ) {
 				ob_start();
+				$attachment_count = count( $attachments );
+				$files = 0;
+				$filesize = 0;
+				foreach( $attachments as $attachment ) {
+					$file_info = ISC_Model::analyze_unused_image( $attachment->metadata );
+					$files += $file_info['files'] ?? 0;
+					$filesize += $file_info['total_size'] ?? 0;
+				}
 				require_once ISCPATH . '/admin/templates/sources/unused-attachments.php';
-				$this->render_sources_page_section( ob_get_clean(), esc_html__( 'Images with unknown position', 'image-source-control-isc' ), 'unused-attachments');
+				$this->render_sources_page_section( ob_get_clean(), esc_html__( 'Unused Images', 'image-source-control-isc' ), 'unused-attachments');
 			}
 
 			$post_type_image_index = ISC_Model::get_posts_with_image_index();

--- a/admin/templates/header.php
+++ b/admin/templates/header.php
@@ -21,7 +21,10 @@
 		<?php break;
 		case 'media_page_isc-sources' : ?>
 				<a href="<?php echo esc_url( admin_url( 'options-general.php?page=isc-settings' ) ); ?>"><?php esc_html_e( 'Settings', 'image-source-control-isc' ); ?></a>
-		<?php break; ?>
+		<?php break;
+		default : ?>
+				<a href="<?php echo esc_url( admin_url( 'upload.php?page=isc-sources' ) ); ?>"><?php esc_html_e( 'Tools', 'image-source-control-isc' ); ?></a>
+				<a href="<?php echo esc_url( admin_url( 'options-general.php?page=isc-settings' ) ); ?>"><?php esc_html_e( 'Settings', 'image-source-control-isc' ); ?></a>
 		<?php endswitch; ?>
 		<a href="<?php echo esc_url( ISC_Admin::get_manual_url( 'header-manual' ) ); ?>" target="_blank"><?php esc_html_e( 'Manual', 'image-source-control-isc' ); ?></a>
 	</div>

--- a/admin/templates/sources/unused-attachments.php
+++ b/admin/templates/sources/unused-attachments.php
@@ -1,35 +1,41 @@
 <?php
 /**
- * Render view wit unused attachments
+ * Render view for possibly unused attachments
  *
- * @var array $attachments list of attachments without association to a post
+ * @var int $attachment_count number of attachments
+ * @var int $files total number of image files (including scaled versions)
+ * @var int $filesize total size of all attachments
  */
 ?>
-<p><?php esc_html_e( 'The list contains images that neither have sources nor were yet found by ISC on your site.', 'image-source-control-isc' ); ?>&nbsp;
-	<?php esc_html_e( 'They might not need a source after all.', 'image-source-control-isc' ); ?></p>
-<?php if( count( $attachments ) >= ISC_Model::MAX_POSTS ) : ?>
-<p><?php
+<p>
+<?php
+if ( $attachment_count >= ISC_Model::MAX_POSTS ) {
 	printf(
-	// translators: %d is the number of entries in the following table
-		esc_html__( 'The list only shows the last %d images.', 'image-source-control-isc' ),
-		ISC_Model::MAX_POSTS
-	); ?>
+	// translators: %1$d is the number of unused attachments and %2$s their combined filesize, including the unit
+		esc_html__( 'At least %1$d unused image files take up over %2$s in disk space on your server.', 'image-source-control-isc' ),
+		$files,
+		size_format( $filesize )
+	);
+} else {
+	printf(
+	// translators: %d is the number of unused attachments and %s their combined filesize, including the unit
+		esc_html__( '%1$d possibly unused image files take up to %2$s in disk space on your server.', 'image-source-control-isc' ),
+		$files,
+		size_format( $filesize )
+	);
+}
+?>
 </p>
-<?php endif; ?>
-<table class="widefat striped isc-table" style="width: 80%;" >
-	<thead>
-	<tr>
-		<th><?php esc_html_e( 'Thumbnail', 'image-source-control-isc' ); ?></th>
-		<th><?php esc_html_e( 'Image title', 'image-source-control-isc' ); ?></th>
-	</tr>
-	</thead><tbody>
+<p>
+<?php
+if ( ! class_exists( 'ISC_Pro_Admin' ) ) :
+	?>
+	<a href="<?php echo esc_url( ISC_Admin::get_isc_localized_website_url( 'l/_unused-images', 'z/_ungenutzte-bilder', 'unused-images' ) ); ?>" target="_blank" class="button button-primary"><?php esc_html_e( 'Clean up unused images', 'image-source-control-isc' ); ?> (Pro)</a>
 	<?php
-	foreach ( $attachments as $_attachment ) :
-		?>
-		<tr>
-			<td><?php edit_post_link( wp_get_attachment_image( $_attachment->ID, [ 60, 60 ] ), '', '', $_attachment->ID ); ?></td>
-			<td><?php edit_post_link( esc_html( $_attachment->post_title ), '', '', $_attachment->ID ); ?></td>
-		</tr>
-	<?php endforeach; ?>
-	</tbody>
-</table>
+else :
+	?>
+	<a href="<?php echo esc_url( admin_url( 'upload.php?page=isc-unused-images' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Clean up unused images', 'image-source-control-isc' ); ?></a>
+	<?php
+endif;
+?>
+</p>

--- a/readme.txt
+++ b/readme.txt
@@ -68,6 +68,7 @@ Check out the premium features to display the image caption overlay for featured
 * Show image sources for Elementor background images, images in Kadence Blocks Galleries, and Kadence Related Content Carousel
 * Developer options to show overlay captions for CSS background images
 * Exclude certain images from showing the overlay by adding the `isc-disable-overlay` class
+* Unused Images – a media cleaner overview of possibly unused images that runs a deep check before removing an image
 * Personal email support
 
 [See Pricing](https://imagesourcecontrol.com/pricing/?utm_source=wporg&utm_medium=link&utm_campaign=pricing).
@@ -110,7 +111,7 @@ e.g.
 
 1. Upload `image-source-control-isc.zip` through the 'Plugin' menu in your WordPress backend
 1. Activate the plugin
-1. Visit _Settings > Image Control_ for the main settings
+1. Visit _Settings > Image Sources_ for the main settings
 
 See the _Instructions_ section [here](https://wordpress.org/plugins/image-source-control-isc/#description).
 
@@ -121,8 +122,14 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 1. display image source within the image
 1. basic settings to customize how to display image sources
 1. settings to manage image source licenses
+1. Unused Images – Media Cleaner feature to safely remove unused images
 
 == Changelog ==
+
+= untagged =
+
+- Feature (Pro): Unused Images feature to help clean up the media library
+- Improvement: combine images without sources and with empty sources in the "Images without sources" list on the Tools page instead of having two separate tables
 
 = 2.15.0 =
 


### PR DESCRIPTION
Combine the previous "unused images" query with the query for empty source information and display them in one table, since they have a similar purpose and the Unused Images label for one of them was misleading.

Show the number and file size of really unused images in the Unused Images table.