### PR TITLE
Unify caption overlay in lightbox

### DIFF
--- a/public/public.php
+++ b/public/public.php
@@ -136,6 +136,10 @@ class ISC_Public extends ISC_Class {
 				// The 2022 theme adds display:block to the featured image block, which creates additional line breaks. `display: inline` fixes that.
 				?>
 				span.isc-source-text a { display: inline; color: #fff; }
+				<?php
+				// force the overlay caption into the bottom left corner for lightboxes introduced in WP 6.4 since otherwise, for some positions, the caption wasn’t visible at all
+				?>
+                .wp-lightbox-overlay.active .isc-source-text { top: initial !important; left: initial !important; bottom: 0! important; }
 			</style>
 			<?php
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 = untagged =
 
 - Improvement: create a unique name for the log file
+- Improvement: always show the overlay caption in the bottom left in the lightbox (added in WordPress 6.4) to prevent it from not showing at all in some cases
 
 = 2.17.0 =
 


### PR DESCRIPTION
force the overlay caption into the bottom left corner for lightboxes introduced in WP 6.4 since otherwise, for some positions, the caption wasn’t visible at all.

There is possibly a cleaner way to solve this, but experience tells me that WordPress might update this feature anyway, in the near future and themes might also interfere. Let’s see how it is used before making further changes.