### PR TITLE
Fix saving custom text

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -933,7 +933,7 @@ class ISC_Admin extends ISC_Class {
 		if ( isset( $input['by_author_text'] ) ) {
 			$output['standard_source_text'] = esc_html( $input['by_author_text'] );
 		} else {
-			$output['standard_source_text'] = ISC\Includes\Standard_Source::get_standard_source_text();
+			$output['standard_source_text'] = isset( $input['standard_source_text'] ) ? esc_attr( $input['standard_source_text'] ) : ISC\Includes\Standard_Source::get_standard_source_text();
 		}
 
 		/**


### PR DESCRIPTION
As a regression in 436ba99676426ca23b86cce7d4bba0f3f5e43e05, the text for custom standard sources was not saved anymore. This commit fixes that.