### PR TITLE
Added isc_can_load filter

### DIFF
--- a/public/public.php
+++ b/public/public.php
@@ -70,7 +70,7 @@ class ISC_Public extends ISC_Class {
 			return false;
 		}
 
-		return true;
+		return apply_filters( 'isc_can_load', '__return_true' );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 - Fix: pre-select the "custom text" standard source option when the plugin options weren’t saved yet to reflect how this state behaves in the frontend
 - Dev: move all features related to the standard source into ISC\Standard_Source
 - Dev: replace the `isc_raw_attachment_use_standard_source` and `isc_public_attachment_use_standard_source` with the `isc_use_standard_source_for_attachment` filter
+- Dev: added the `isc_can_load` filter to allow developers to disable ISC on certain pages in the frontend
 
 = 2.17.1 =
 


### PR DESCRIPTION
The `isc_can_load` filter can be used to disable ISC on certain pages or page types in the frontend.

E.g., disable it on all non-single pages:

```
add_filter( 'isc_can_load', function( $can_load ) {
	return is_single();
} );
```