### PR TITLE
Hide empty source entries

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -49,6 +49,10 @@
 	<rule ref="Squiz.Commenting.FileComment">
 		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
 	</rule>
+	<!-- Disable warning about missing punctuation at the end of inline comments -->
+	<rule ref="Squiz.Commenting.InlineComment">
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
+	</rule>
 
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
@@ -68,6 +72,11 @@
 	<rule ref="WordPress.PHP.StrictInArray">
         <type>error</type>
     </rule>
+
+	<!-- Disable Yoda condition checks -->
+	<rule ref="WordPress.PHP.YodaConditions">
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
+	</rule>
 
 	<!-- Method names MUST NOT be prefixed with a single underscore to indicate protected or private visibility. That is, an underscore prefix explicitly has no meaning. -->
     <rule ref="PSR2.Methods.MethodDeclaration.Underscore">

--- a/public/public.php
+++ b/public/public.php
@@ -467,14 +467,14 @@ class ISC_Public extends ISC_Class {
 
 		if ( ! empty( $attachments ) ) {
 			ISC_Log::log( sprintf( 'going through %d attachments', count( $attachments ) ) );
-			$atts = array();
+			$atts = [];
 			foreach ( $attachments as $attachment_id => $attachment_array ) {
 				$use_standard_source = Standard_Source::use_standard_source( $attachment_id );
 				$source              = self::get_image_source_text( $attachment_id );
 
 				// check if source of own images can be displayed
-				if ( ( $use_standard_source == '' && $source == '' ) || ( $use_standard_source != '' && $exclude_standard ) ) {
-					if ( $use_standard_source != '' && $exclude_standard ) {
+				if ( ( $use_standard_source === '' && $source === '' ) || ( $use_standard_source !== '' && $exclude_standard ) ) {
+					if ( $use_standard_source !== '' && $exclude_standard ) {
 						ISC_Log::log( sprintf( 'image %d: "own" sources are excluded', $attachment_id ) );
 					} else {
 						ISC_Log::log( sprintf( 'image %d: skipped because of empty source', $attachment_id ) );
@@ -493,7 +493,7 @@ class ISC_Public extends ISC_Class {
 
 			return $this->render_attachments( $atts );
 		} else {
-			// see description above
+			// see description above.
 			ISC_Log::log( 'exit list_post_attachments_with_sources() without any images found ' );
 			// allow to return result if the source list is empty.
 			return apply_filters( 'isc_source_list_empty_output', '' );

--- a/public/public.php
+++ b/public/public.php
@@ -480,11 +480,14 @@ class ISC_Public extends ISC_Class {
 						ISC_Log::log( sprintf( 'image %d: skipped because of empty source', $attachment_id ) );
 					}
 					unset( $atts[ $attachment_id ] );
-					continue;
 				} else {
 					$atts[ $attachment_id ]['title'] = get_the_title( $attachment_id );
 					ISC_Log::log( sprintf( 'image %d: getting title "%s"', $attachment_id, $atts[ $attachment_id ]['title'] ) );
 					$atts[ $attachment_id ]['source'] = $this->render_image_source_string( $attachment_id );
+					if ( ! $atts[ $attachment_id ]['source'] ) {
+						ISC_Log::log( sprintf( 'image %d: skipped because of empty standard source', $attachment_id ) );
+						unset( $atts[ $attachment_id ] );
+					}
 				}
 			}
 


### PR DESCRIPTION
Two changes:

- an empty standard source could cause the per-page list to show up with a headline but no entries
- removed Yoda condition check and punctuation at the end of inline comments in PHPCS