### PR TITLE
Add isc_force_block_options filter

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -233,7 +233,10 @@ class ISC_Admin extends ISC_Class {
 		 * Return, when the ISC fields are enabled for blocks and the HTTP_REFERER is a post edit page. This likely means, that the block editor is used.
 		 * While the URL to edit an attachment can also include "wp-admin.php.php", the HTTP_REFERER is then different
 		 */
-		if ( ! empty( $_SERVER['HTTP_REFERER'] ) && strpos( $_SERVER['HTTP_REFERER'], 'wp-admin/post.php' ) !== false && ( ! array_key_exists( 'block_options', $options ) || $options['block_options'] ) ) {
+		if ( ! empty( $_SERVER['HTTP_REFERER'] )
+			&& strpos( $_SERVER['HTTP_REFERER'], 'wp-admin/post.php' ) !== false
+			// the filter allows users to force the ISC fields and Block options at the same time
+			&& ( ISC_Block_Options::enabled() && ! apply_filters( 'isc_force_block_options', false ) ) ) {
 			return $form_fields;
 		}
 
@@ -731,8 +734,9 @@ class ISC_Admin extends ISC_Class {
 	 * Render options for block editor support
 	 */
 	public function renderfield_block_options() {
-		$options = $this->get_isc_options();
-		$checked = ! array_key_exists( 'block_options', $options ) || $options['block_options'];
+		$options  = $this->get_isc_options();
+		$checked  = ISC_Block_Options::enabled();
+		$disabled = apply_filters( 'isc_force_block_options', false );
 		require_once ISCPATH . '/admin/templates/settings/block-options.php';
 	}
 

--- a/admin/templates/settings/block-options.php
+++ b/admin/templates/settings/block-options.php
@@ -2,11 +2,13 @@
 /**
  * Render the block options setting
  *
- * @var bool $checked if the block options option is enabled.
+ * @var bool $checked if the block option is enabled.
+ * @var bool $disabled if the block option is disabled.
  */
+
 ?>
 <label>
-	<input type="checkbox" name="isc_options[block_options]" value="1" <?php checked( $checked ); ?>/>
+	<input type="checkbox" name="isc_options[block_options]" value="1" <?php checked( $checked ); ?> <?php disabled( $disabled ); ?>/>
 	<?php esc_html_e( 'Show source options in block settings.', 'image-source-control-isc' ); ?>
 	<?php esc_html_e( 'If disabled, the source options will show in the media library overlay.', 'image-source-control-isc' ); ?>
 </label>

--- a/includes/block-options/block-options.php
+++ b/includes/block-options/block-options.php
@@ -8,16 +8,29 @@ class ISC_Block_Options {
 	 * Construct an instance of ISC_Block_Options
 	 */
 	public function __construct() {
-		if ( ! function_exists( 'register_block_type' ) ) {
+		if ( ! function_exists( 'register_block_type' ) || ! self::enabled() ) {
 			return;
 		}
 
+		add_action( 'enqueue_block_editor_assets', [ $this, 'editor_assets' ] );
+		add_action( 'init', [ $this, 'init' ] );
+		add_action( 'update_option', [ $this, 'widgets_update_option' ], 10, 3 );
+	}
+
+	/**
+	 * Check, if block options are enabled
+	 *
+	 * @return bool
+	 */
+	public static function enabled(): bool {
 		$options = ISC_Class::get_instance()->get_isc_options();
-		if ( ! array_key_exists( 'block_options', $options ) || $options['block_options'] ) {
-			add_action( 'enqueue_block_editor_assets', array( $this, 'editor_assets' ) );
-			add_action( 'init', array( $this, 'init' ) );
-			add_action( 'update_option', array( $this, 'widgets_update_option' ), 10, 3 );
+		// if settings don’t exist, block options are enabled by default
+		if ( ! array_key_exists( 'block_options', $options )
+			|| $options['block_options']
+			|| apply_filters( 'isc_force_block_options', false ) ) {
+			return true;
 		}
+		return false;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -135,6 +135,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 - Dev: move all features related to the standard source into ISC\Standard_Source
 - Dev: replace the `isc_raw_attachment_use_standard_source` and `isc_public_attachment_use_standard_source` with the `isc_use_standard_source_for_attachment` filter
 - Dev: added the `isc_can_load` filter to allow developers to disable ISC on certain pages in the frontend
+- Dev: you can use the `isc_force_block_options` filter hook to enable ISC fields in the block options and media modal in the block editor at the same time
 
 = 2.17.1 =
 


### PR DESCRIPTION
Developers can use the `isc_force_block_options` filter hook to enable the ISC fields in the block options and media modal in the bock editor at the same time.

Some code improvements to simplify the checks.