### PR TITLE
Media button

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -234,9 +234,17 @@ class ISC_Admin extends ISC_Class {
 		 * While the URL to edit an attachment can also include "wp-admin.php.php", the HTTP_REFERER is then different
 		 */
 		if ( ! empty( $_SERVER['HTTP_REFERER'] )
+			 // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 			&& strpos( $_SERVER['HTTP_REFERER'], 'wp-admin/post.php' ) !== false
 			// the filter allows users to force the ISC fields and Block options at the same time
 			&& ( ISC_Block_Options::enabled() && ! apply_filters( 'isc_force_block_options', false ) ) ) {
+
+			$form_fields['isc_field_note'] = [
+				'label' => __( 'Image Source', 'image-source-control-isc' ),
+				'input' => 'html',
+				'html'  => __( 'Find the image source fields in the image block options or media library.', 'image-source-control-isc' ),
+			];
+
 			return $form_fields;
 		}
 

--- a/includes/block-options/block-options.php
+++ b/includes/block-options/block-options.php
@@ -9,6 +9,8 @@ class ISC_Block_Options {
 	 */
 	public function __construct() {
 		if ( ! function_exists( 'register_block_type' ) || ! self::enabled() ) {
+			// if block options are disabled, at least add a link to the media library where one can adjust the source
+			add_action( 'enqueue_block_editor_assets', [ $this, 'edit_link_assets' ] );
 			return;
 		}
 
@@ -161,6 +163,19 @@ class ISC_Block_Options {
 		wp_enqueue_script( 'isc/image-block' );
 
 		wp_enqueue_script( 'isc/media-upload', trailingslashit( ISCBASEURL ) . 'admin/assets/js/media-upload.js', array( 'media-upload' ), ISCVERSION, true );
+	}
+
+	/**
+	 * Enqueue script to add an edit button to image blocks
+	 */
+	public function edit_link_assets() {
+		wp_enqueue_script(
+			'isc/image-block-edit-link',
+			plugin_dir_url( __FILE__ ) . 'isc-image-block-edit-link.js',
+			[ 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor' ],
+			ISCVERSION,
+			true // load in the footer
+		);
 	}
 
 }

--- a/includes/block-options/isc-image-block-edit-link.js
+++ b/includes/block-options/isc-image-block-edit-link.js
@@ -1,0 +1,95 @@
+/**
+ * Add a link to the media modal when Image Source Control fields for image blocks are disabled.
+ *
+ * @param {object} wp - The WordPress global object.
+ */
+
+( function ( wp ) {
+	'use strict';
+
+	var __                          = wp.i18n.__;
+	var el                          = wp.element.createElement;
+	var createHigherOrderComponent  = wp.compose.createHigherOrderComponent;
+	var MediaUpload                 = wp.blockEditor.MediaUpload;
+	var PanelBody                   = wp.components.PanelBody;
+	var InspectorControls           = wp.blockEditor.InspectorControls;
+	var enableSourceControlOnBlocks = ['core/image', 'core/cover', 'core/media-text', 'core/post-featured-image'];
+
+	var iscWithoutSources = createHigherOrderComponent(
+		function ( BlockEdit ) {
+			return function ( props ) {
+				// Do nothing if it's another block than our defined ones.
+				if ( ! enableSourceControlOnBlocks.includes( props.name ) ) {
+					return el( BlockEdit, props );
+				}
+
+				var id = props.attributes.id || props.attributes.mediaId;
+
+				// If an image has not been selected yet, do not display the source control fields.
+				if ( isNaN( id ) || id === 0 ) {
+					return el( BlockEdit, props );
+				}
+
+				var selectMediaButton = el(
+					MediaUpload,
+					{
+						onSelect:     function ( media ) {
+							// nothing happens on select
+						},
+						allowedTypes: ['image'],
+						value:        id,
+						render:       function ( obj ) {
+							var Tooltip = wp.components.Tooltip;
+							var Button  = wp.components.Button;
+
+							return el(
+								React.Fragment,
+								{},
+								el(
+									Tooltip,
+									{
+										text: el(
+											React.Fragment,
+											{},
+											__( 'Click here to edit image source information in the media modal.', 'image-source-control-isc' ),
+											el( 'br' ),
+											__( 'You can also enable the block options in the plugin settings to see the image source fields below.', 'image-source-control-isc' )
+										)
+									},
+									el(
+										Button,
+										{
+											onClick:   obj.open,
+											className: 'components-icon-button components-toolbar__control',
+											label:     __( 'Edit image source', 'image-source-control-isc' )
+										},
+										__( 'Edit image source', 'image-source-control-isc' )
+									)
+								)
+							);
+						}
+					}
+				);
+
+				var panelBody = el(
+					PanelBody,
+					{
+						title:       'Image Source Control',
+						initialOpen: true
+					},
+					selectMediaButton
+				);
+
+				return el(
+					wp.element.Fragment,
+					{},
+					el( BlockEdit, props ),
+					el( InspectorControls, {}, panelBody )
+				);
+			};
+		},
+		'withoutSources'
+	);
+
+	wp.hooks.addFilter( 'editor.BlockEdit', 'image-source-control/without-sources', iscWithoutSources );
+} )( window.wp );


### PR DESCRIPTION
This PR helps with confusion about where to find the image source fields on post edit pages, since they can only appear either in the block options or media library modal.

Depending on the block option setting, a note is displayed about where to find the fields.