### PR TITLE
Replace individual Pro links with just one

### DIFF
--- a/admin/templates/settings/overlay-advanced-included-images.php
+++ b/admin/templates/settings/overlay-advanced-included-images.php
@@ -3,7 +3,7 @@
  * Render the advanced included images option for captions
  *
  * @var array $checked_advanced_options selected options
- * @var array $advanced_options available options.
+ * @var array $advanced_options         available options.
  */
 ?>
 <h4><?php esc_html_e( 'Developer Options', 'image-source-control-isc' ); ?></h4>
@@ -14,42 +14,44 @@
 <div>
 	<?php
 	foreach ( $advanced_options as $_key => $_options ) :
-		$value  = $_options['value'] ?? '';
-		$is_pro = ! empty( $_options['is_pro'] );
+		$value = $_options['value'] ?? '';
 		?>
 		<label>
 			<input type="checkbox" name="isc_options[overlay_included_advanced][]" value="<?php echo esc_attr( $value ); ?>"
 				<?php checked( in_array( $value, $checked_advanced_options ) ); ?>
-				<?php echo $is_pro ? 'disabled="disabled" class="is-pro"' : ''; ?>
+				<?php echo ! empty( $_options['is_pro'] ) ? 'disabled="disabled" class="is-pro"' : ''; ?>
 			/>
-			<?php if ( isset( $_options['label'] ) ) :
+			<?php
+			if ( isset( $_options['label'] ) ) :
 				echo wp_kses(
 					$_options['label'],
-					array(
-						'code' => array(),
-					)
+					[
+						'code' => [],
+					]
 				);
 			endif;
-			  ?>
+			?>
 		</label>
-			<?php
-			if ( isset( $_options['description'] ) ) :
-				?>
-		<p class="description">
+		<?php
+		if ( isset( $_options['description'] ) ) :
+			?>
+			<p class="description">
 				<?php
 				echo wp_kses(
 					$_options['description'],
-					array(
-						'code' => array(),
-					)
+					[
+						'code' => [],
+					]
 				);
 				?>
-		</p>
-				<?php
-			else :
-				?><br><?php
-			endif;
+			</p>
+			<?php
+		else :
 			?>
+			<br>
+			<?php
+		endif;
+		?>
 	<?php endforeach; ?>
 	<?php if ( ! class_exists( 'ISC_Pro_Admin', false ) ) : ?>
 		<p>

--- a/admin/templates/settings/overlay-advanced-included-images.php
+++ b/admin/templates/settings/overlay-advanced-included-images.php
@@ -22,7 +22,6 @@
 				<?php checked( in_array( $value, $checked_advanced_options ) ); ?>
 				<?php echo $is_pro ? 'disabled="disabled" class="is-pro"' : ''; ?>
 			/>
-			<?php if ( $is_pro ) : echo ISC_Admin::get_pro_link( 'overlay-' . sanitize_title( $_options['label'] ) ); endif; ?>
 			<?php if ( isset( $_options['label'] ) ) :
 				echo wp_kses(
 					$_options['label'],
@@ -52,4 +51,9 @@
 			endif;
 			?>
 	<?php endforeach; ?>
+	<?php if ( ! class_exists( 'ISC_Pro_Admin', false ) ) : ?>
+		<p>
+			<?php echo ISC_Admin::get_pro_link( 'overlay-developer-options-pitch' ); ?>
+		</p>
+	<?php endif; ?>
 </div>


### PR DESCRIPTION
Each of the developer options was marked with a link to Pro, which created too much visual noise. While this could be optimized further, replacing all links with just one is already an improvement.