### PR TITLE
Improve unused images check

### DIFF
--- a/admin/templates/sources/unused-attachments.php
+++ b/admin/templates/sources/unused-attachments.php
@@ -12,16 +12,22 @@
 if ( $attachment_count >= ISC_Model::MAX_POSTS ) {
 	printf(
 	// translators: %1$d is the number of unused attachments and %2$s their combined filesize, including the unit
-		esc_html__( 'At least %1$d unused image files take up over %2$s in disk space on your server.', 'image-source-control-isc' ),
-		$files,
-		size_format( $filesize )
+		esc_html__( 'At least %d unused image files.', 'image-source-control-isc' ),
+		(int) $files
 	);
 } else {
 	printf(
 	// translators: %d is the number of unused attachments and %s their combined filesize, including the unit
-		esc_html__( '%1$d possibly unused image files take up to %2$s in disk space on your server.', 'image-source-control-isc' ),
-		$files,
-		size_format( $filesize )
+		esc_html__( '%d possibly unused image files.', 'image-source-control-isc' ),
+		(int) $files
+	);
+}
+if ( $filesize > 1000000 ) {
+	echo ' ';
+	printf(
+	// translators: %s is the number of unused attachments
+		esc_html__( 'They take up at least %s in disk space on your server.', 'image-source-control-isc' ),
+		esc_html( size_format( $filesize ) )
 	);
 }
 ?>

--- a/includes/model.php
+++ b/includes/model.php
@@ -509,8 +509,8 @@ class ISC_Model {
 	 */
 	public static function analyze_unused_image( $image_metadata ): array {
 		$information = [
-			'files' => 0,
-			'total_size'  => 0,
+			'files'      => 0,
+			'total_size' => 0,
 		];
 
 		if ( empty( $image_metadata ) ) {
@@ -520,21 +520,31 @@ class ISC_Model {
 		$image_metadata = maybe_unserialize( $image_metadata );
 
 		if ( isset( $image_metadata['filesize'] ) ) {
-			$information['files']++;
 			$information['total_size'] += (int) $image_metadata['filesize'];
+		}
+
+		if ( isset( $image_metadata['file'] ) ) {
+			++$information['files'];
+		}
+
+		if ( isset( $image_metadata['original_image'] ) ) {
+			++$information['files'];
 		}
 
 		foreach ( $image_metadata as $value ) {
 			if ( is_array( $value ) ) {
 				if ( isset( $value['filesize'] ) ) {
-					$information['files']++;
 					$information['total_size'] += (int) $value['filesize'];
+				}
+
+				if ( isset( $value['file'] ) ) {
+					++$information['files'];
 				}
 
 				// If the current value contains nested arrays (e.g., 'sizes'), recursively call the function
 				if ( is_array( reset( $value ) ) ) {
-					$return = self::analyze_unused_image( $value );
-					$information['files'] += (int) $return['files'] ?? 0;
+					$return                     = self::analyze_unused_image( $value );
+					$information['files']      += (int) $return['files'] ?? 0;
 					$information['total_size'] += (int) $return['total_size'] ?? 0;
 				}
 			}


### PR DESCRIPTION
On an older site, the number of unused images and file size was not calculated correctly because the attachment meta data seems to have changed over time. It seems to not have contained `filesize` in the past, but many of our checks depend on that.

This commit makes counting independent of `filesize`. It also counts `original_image` individually, which is only set in some cases.