### PR TITLE
Custom maybe_unserialize() function

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -26,4 +26,22 @@ class Helpers {
 
 		return false;
 	}
+
+	/**
+	 * Securely unserialize a WordPress option
+	 * a copy of WP core’s maybe_unserialize() function with additional code to prevent object injection
+	 * See https://www.tenable.com/security/research/tra-2023-7 about the risks of object injections
+	 *
+	 * @param string $data value to unserialize.
+	 *
+	 * @return mixed Unserialized data can be any type.
+	 */
+	public static function maybe_unserialize( $data ) {
+		if ( is_serialized( $data ) ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize, WordPress.PHP.NoSilencedErrors.Discouraged -- unserialize() is the only way to unserialize WP options
+			return @unserialize( trim( $data ), [ 'allowed_classes' => false ] );
+		}
+
+		return $data;
+	}
 }

--- a/includes/unused-images.php
+++ b/includes/unused-images.php
@@ -77,7 +77,7 @@ class Unused_Images {
 			return $information;
 		}
 
-		$image_metadata = maybe_unserialize( $image_metadata );
+		$image_metadata = Helpers::maybe_unserialize( $image_metadata );
 
 		if ( isset( $image_metadata['file'] ) ) {
 			++$information['files'];


### PR DESCRIPTION
With even WordPress core functions to unserialize options being unsafe if going through unknown data, I introduced a new function that is a copy of the core `maybe_unserialize()` with an additional flag to not allow classes.

Replaced the only usage of core’s `maybe_unserialize` with the new helper function.