### PR TITLE
Store activation date

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -979,6 +979,11 @@ class ISC_Admin extends ISC_Class {
 			$output['standard_source_text'] = isset( $input['standard_source_text'] ) ? esc_attr( $input['standard_source_text'] ) : ISC\Standard_Source::get_standard_source_text();
 		}
 
+		// add activation date when the settings are saved for the first time
+		if ( ! array_key_exists( 'activated', $output ) ) {
+			$output['activated'] = time();
+		}
+
 		/**
 		 * Allow other developers to manipulate settings on save
 		 */

--- a/includes/feedback.php
+++ b/includes/feedback.php
@@ -81,11 +81,10 @@ class Feedback {
 
 		$data = $this->prepare_feedback_data( $_POST );
 
-		$installed = $data['installed'];
-		$from      = $data['from'];
-		$subject   = 'Image Source Control Feedback';
-		$text      = $data['text'];
-		$text     .= "\n\n" . home_url() . " ($installed)";
+		$from    = $data['from'];
+		$subject = 'Image Source Control Feedback';
+		$text    = $data['text'];
+		$text   .= "\n\n" . home_url() . ' (' . $data['activated'] . ')';
 
 		// The user sent feedback with a reply request
 		if (
@@ -127,7 +126,7 @@ class Feedback {
 		$feedback['email'] = ! array_key_exists( 'isc-feedback-reply-email', $data ) || ! is_email( $data['isc-feedback-reply-email'] ) ? '' : trim( $data['isc-feedback-reply-email'] );
 
 		$options               = ISC_Class::get_instance()->get_isc_options();
-		$feedback['installed'] = isset( $options['installed'] ) ? gmdate( 'd.m.Y', $options['installed'] ) : '–';
+		$feedback['activated'] = isset( $options['activated'] ) ? gmdate( 'd.m.Y', $options['activated'] ) : '–';
 
 		return $feedback;
 	}

--- a/includes/isc.class.php
+++ b/includes/isc.class.php
@@ -190,7 +190,9 @@ class ISC_Class {
 		}
 
 		/**
-		 *   Returns default options
+		 * Returns default options
+		 *
+		 * @return string[]
 		 */
 		public function default_options() {
 			include ISCPATH . 'includes/default-licenses.php';
@@ -227,6 +229,8 @@ class ISC_Class {
 
 		/**
 		 * Returns isc_options if it exists, returns the default options otherwise.
+		 *
+		 * @return string[]
 		 */
 		public function get_isc_options() {
 			return get_option( 'isc_options', $this->default_options() );


### PR DESCRIPTION
Store the date the plugin options were first saved as a pseudo activation-date and send it when users give feedback on deactivation.