### PR TITLE
Move block options check

### DIFF
--- a/includes/block-options/block-options.php
+++ b/includes/block-options/block-options.php
@@ -8,6 +8,13 @@ class ISC_Block_Options {
 	 * Construct an instance of ISC_Block_Options
 	 */
 	public function __construct() {
+		add_action( 'plugins_loaded', [ $this, 'plugins_loaded' ] );
+	}
+
+	/**
+	 * Register hooks
+	 */
+	public function plugins_loaded() {
 		if ( ! function_exists( 'register_block_type' ) || ! self::enabled() ) {
 			// if block options are disabled, at least add a link to the media library where one can adjust the source
 			add_action( 'enqueue_block_editor_assets', [ $this, 'edit_link_assets' ] );


### PR DESCRIPTION
The `__construct()` method of `ISC_Block_Options` used a function too early and caused occasional PHP errors. I moved it into `plugins_loaded`