### PR TITLE
Allow to close the signup form

### DIFF
--- a/admin/assets/css/isc.css
+++ b/admin/assets/css/isc.css
@@ -74,6 +74,7 @@
 .isc-settings-highlighted .description { margin-left: 1.7em; margin-bottom: .5em; }
 #isc-settings-licenses textarea { width: 40em; height: 7em; }
 #isc-section-wrapper .hndle { cursor: text; user-select: all; }
+#isc-section-wrapper .postbox-header .dashicons-no-alt { cursor: pointer; margin-right: 8px; }
 #thumbnail-size-select { vertical-align: baseline;}
 
 #isc-settings-caption-position-options-wrapper:not(.hidden) {

--- a/admin/assets/js/settings.js
+++ b/admin/assets/js/settings.js
@@ -62,6 +62,24 @@ jQuery( document ).ready(
 				}
 			});
 		});
+		// close the newsletter signup box without signing up
+		$('#isc_settings_section_signup .postbox-header .dashicons-no-alt').on( 'click', function() {
+			$('#isc-signup-nl').prop( 'disabled', true );
+			$('#isc-signup-loader').removeClass('hidden');
+			$.ajax({
+				type: 'POST',
+				url: ajaxurl,
+				data: {
+					action: 'newsletter_close',
+					nonce: isc.ajaxNonce,
+				},
+				dataType: 'json',
+				success: function( response ) {
+					$('#isc_settings_section_signup').remove();
+				}
+			});
+		});
+
 		// Add special characters to the source-pretext field by clicking on a button
 		document.querySelectorAll('#source-pretext-buttons button').forEach( function( button ) {
 			button.addEventListener('click', function() {

--- a/admin/templates/settings/settings.php
+++ b/admin/templates/settings/settings.php
@@ -17,7 +17,11 @@
 				<?php
 				if ( $section['title'] ) {
 					?>
-					<div class="postbox-header"><h2 class="hndle"><?php echo esc_html( $section['title'] ); ?></h2></div>
+					<div class="postbox-header"><h2 class="hndle"><?php echo esc_html( $section['title'] ); ?></h2>
+					<?php if ( ! empty( $section['close_button'] ) ) : ?>
+						<span class="dashicons dashicons-no-alt"></span>
+					<?php endif; ?>
+					</div>
 					<?php
 				}
 				?>

--- a/includes/newsletter.php
+++ b/includes/newsletter.php
@@ -72,6 +72,13 @@ class Newsletter {
 	}
 
 	/**
+	 * Close the newsletter box
+	 */
+	public function close() {
+		update_user_meta( get_current_user_id(), 'isc_newsletter_closed', true );
+	}
+
+	/**
 	 * Check if the user is subscribed to the newsletter
 	 *
 	 * @return bool
@@ -80,6 +87,17 @@ class Newsletter {
 		$user_id = get_current_user_id();
 
 		return ! $user_id || get_user_meta( $user_id, 'isc_newsletter_subscribed', true );
+	}
+
+	/**
+	 * Check if the user closed the newsletter box
+	 *
+	 * @return bool
+	 */
+	public function current_user_closed_signup(): bool {
+		$user_id = get_current_user_id();
+
+		return ! $user_id || get_user_meta( $user_id, 'isc_newsletter_closed', true );
 	}
 
 	/**

--- a/includes/settings/sections/newsletter.php
+++ b/includes/settings/sections/newsletter.php
@@ -22,13 +22,14 @@ class Newsletter {
 	public function __construct() {
 		$this->newsletter = new \ISC\Newsletter();
 
-		if ( $this->newsletter->current_user_is_subscribed() ) {
+		if ( $this->newsletter->current_user_is_subscribed() || $this->newsletter->current_user_closed_signup() ) {
 			return;
 		}
 
 		$this->add_settings_section();
 
 		add_action( 'wp_ajax_newsletter_signup', [ $this, 'newsletter_signup' ] );
+		add_action( 'wp_ajax_newsletter_close', [ $this, 'close_newsletter_box' ] );
 	}
 
 	/**
@@ -39,7 +40,8 @@ class Newsletter {
 			'isc_settings_section_signup',
 			__( 'Newsletter', 'image-source-control-isc' ),
 			[ $this, 'render_settings_section' ],
-			'isc_settings_page'
+			'isc_settings_page',
+			[ 'close_button' => true ]
 		);
 	}
 
@@ -70,6 +72,28 @@ class Newsletter {
 		$response = [
 			'success' => true,
 			'message' => $return['message'],
+		];
+		echo wp_json_encode( $response );
+
+		die();
+	}
+
+	/**
+	 * AJAX handler to close the newsletter box and never show it again
+	 *
+	 * @return void
+	 */
+	public function close_newsletter_box() {
+		check_ajax_referer( 'isc-admin-ajax-nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			die();
+		}
+
+		$this->newsletter->close();
+
+		$response = [
+			'success' => true,
 		];
 		echo wp_json_encode( $response );
 


### PR DESCRIPTION
A close button was added to the newsletter signup box on the settings page allowing to close it indefinitely.