### PR TITLE
Option to enable WP Bakery support

### DIFF
--- a/admin/templates/settings/caption/overlay-advanced-included-images.php
+++ b/admin/templates/settings/caption/overlay-advanced-included-images.php
@@ -27,6 +27,10 @@
 					$_options['label'],
 					[
 						'code' => [],
+						'a'    => [
+							'href'   => [],
+							'target' => [],
+						],
 					]
 				);
 			endif;

--- a/includes/settings/sections/caption.php
+++ b/includes/settings/sections/caption.php
@@ -201,6 +201,21 @@ class Caption extends Settings\Section {
 			array_unshift( $options, $avada_builder_option );
 		}
 
+		// push WP Bakery option as the first option
+		if ( defined( 'WPB_VC_VERSION' ) ) {
+			$wp_bakery_option = [
+				'label'  => 'WP Bakery: ' . __( 'Display the overlay text for background images', 'image-source-control-isc' )
+					. '. ' . sprintf(
+						'<a href="%s" target="_blank">%s</a>',
+						'https://imagesourcecontrol.com/documentation/compatibility/#WPBakery_Page_Builder',
+						__( 'Manual', 'image-source-control-isc' )
+					),
+				'value'  => 'wp_bakery_background_overlay',
+				'is_pro' => true,
+			];
+			array_unshift( $options, $wp_bakery_option );
+		}
+
 		return apply_filters( 'isc_overlay_advanced_included_images_options', $options );
 	}
 


### PR DESCRIPTION
Support for background images in the WP Bakery page builder  was added in Pro. The option to enable it was integrated into the base code to make it more visible.