### PR TITLE
Extend log entries

### DIFF
--- a/includes/analyze-html.php
+++ b/includes/analyze-html.php
@@ -81,9 +81,9 @@ class Analyze_HTML {
 		$success = preg_match( '#wp-image-(\d+)|data-id="(\d+)#is', $html, $matches_id );
 		if ( $success ) {
 			$id = $matches_id[1] ? intval( $matches_id[1] ) : intval( $matches_id[2] );
-			\ISC_Log::log( sprintf( 'ISC\Analyze_HTML:extract_image_id: found ID "%s"', $id ) );
+			\ISC_Log::log( sprintf( 'found ID "%s"', $id ) );
 		} else {
-			\ISC_Log::log( sprintf( 'ISC\Analyze_HTML:extract_image_id: no ID found for "%s"', $html ) );
+			\ISC_Log::log( sprintf( 'no ID found for "%s"', $html ) );
 		}
 
 		return $id;
@@ -105,9 +105,9 @@ class Analyze_HTML {
 		$success = preg_match( '#src="([^"]+)"#is', $html, $matches_src );
 		if ( $success ) {
 			$src = $matches_src[1];
-			\ISC_Log::log( sprintf( 'ISC\Analyze_HTML:extract_image_src: found src "%s"', $src ) );
+			\ISC_Log::log( sprintf( 'found src "%s"', $src ) );
 		} else {
-			\ISC_Log::log( sprintf( 'ISC\Analyze_HTML:extract_image_src: no src found for "%s"', $html ) );
+			\ISC_Log::log( sprintf( 'no src found for "%s"', $html ) );
 		}
 
 		return $src;

--- a/includes/log.php
+++ b/includes/log.php
@@ -15,12 +15,41 @@ class ISC_Log {
 	}
 
 	/**
+	 * Check the log type
+	 *
+	 * @param string $type Type of the log depth.
+	 *
+	 * @return bool
+	 */
+	public static function is_type( string $type ): bool {
+		return self::get_type() === $type;
+	}
+
+	/**
+	 * Return the log type
+	 *
+	 * Type of the log depth
+	 * - default
+	 * - content - logs the content
+	 * - backtrace - logs the function backtrace
+	 */
+	private static function get_type(): string {
+		$accepted_types = [ 'default', 'content', 'backtrace' ];
+
+		// phpcs:ignore WordPress.Security.NonceVerification
+		$isc_log = sanitize_key( wp_unslash( $_GET['isc-log'] ?? '' ) );
+
+		return in_array( $isc_log, $accepted_types, true ) ? $isc_log : 'default';
+	}
+
+	/**
 	 * Check if the log feature is enabled
 	 *
 	 * @return bool
 	 */
 	public static function enabled(): bool {
 		// true if the Debug Log option is enabled and the ?isc-log query parameter is set
+		// phpcs:ignore WordPress.Security.NonceVerification
 		return ( ! empty( ISC_Class::get_instance()->get_isc_options()['enable_log'] ) && isset( $_GET['isc-log'] ) );
 	}
 
@@ -37,9 +66,16 @@ class ISC_Log {
 			return;
 		}
 
+		// get the current function name
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 2 );
+		$method    = sprintf( '%s:%s', $backtrace[1]['class'] ?? '', $backtrace[1]['function'] );
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 		$message = is_array( $message ) ? print_r( $message, true ) : $message;
 
-		error_log( '[' . date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) . "] $message\n", 3, self::get_log_file_path() );
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( '[' . date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) . "] $method: $message\n", 3, self::get_log_file_path() );
 	}
 
 	/**
@@ -54,7 +90,7 @@ class ISC_Log {
 	 *
 	 * @return string
 	 */
-	public static function get_log_file_URL(): string {
+	public static function get_log_file_url(): string {
 		return ISCBASEURL . self::get_file_name();
 	}
 
@@ -65,5 +101,38 @@ class ISC_Log {
 	 */
 	public static function get_log_file_path(): string {
 		return ISCPATH . '/' . self::get_file_name();
+	}
+
+	/**
+	 * Return true if internal caches should be ignored
+	 * only works in combination with an activated log
+	 */
+	public static function ignore_caches(): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification
+		return self::enabled() && isset( $_GET['isc-ignore-cache'] );
+	}
+
+	/**
+	 * Return true if the log should be cleared automatically before writing
+	 */
+	public static function clear_log(): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification
+		return self::enabled() && isset( $_GET['isc-clear-log'] );
+	}
+
+	/**
+	 * Print a concise stack trace in the log
+	 */
+	public static function log_stack_trace() {
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
+
+		// remove the "args" key to reduce the output size
+		foreach ( $backtrace as $key => $trace ) {
+			unset( $backtrace[ $key ]['args'] );
+		}
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+		self::log( 'Stack trace: ' . "\n - " . print_r( $backtrace, true ) );
 	}
 }

--- a/includes/model.php
+++ b/includes/model.php
@@ -456,10 +456,10 @@ class ISC_Model {
 	public static function filter_image_ids( $content = '' ) {
 		$srcs = [];
 
-		ISC_Log::log( 'enter filter_image_ids() to look for image IDs within the content' );
+		ISC_Log::log( 'enter looking for image IDs within the content' );
 
 		if ( empty( $content ) ) {
-			ISC_Log::log( 'exit filter_image_ids() due to missing content' );
+			ISC_Log::log( 'exit due to missing content' );
 			return $srcs;
 		}
 
@@ -494,6 +494,14 @@ class ISC_Model {
 			$xpath       = new DOMXpath( $dom );
 			$tags_string = '//' . implode( '|//', $tags );
 			$nodes       = $xpath->query( $tags_string );
+		}
+
+		$nodes_count = count( $nodes );
+
+		ISC_Log::log( sprintf( 'found %d img tags', $nodes_count ) );
+
+		if ( ISC_Log::is_type( 'content' ) ) {
+			ISC_Log::log( sprintf( 'looked in content: %s', $content ) );
 		}
 
 		foreach ( $nodes as $node ) {

--- a/includes/renderer/caption.php
+++ b/includes/renderer/caption.php
@@ -36,13 +36,13 @@ class Caption extends Renderer {
 	public static function get( int $image_id, array $data = [], array $args = [] ) {
 		$source = \ISC_Public::get_instance()->render_image_source_string( $image_id, $data, $args );
 		if ( ! $source ) {
-			ISC_Log::log( sprintf( 'ISC\Render\Caption::get() skipped overlay for empty sources string for ID "%s"', $image_id ) );
+			ISC_Log::log( sprintf( 'skipped overlay for empty sources string for ID "%s"', $image_id ) );
 			return '';
 		}
 
 		// don’t render the caption for own images if the admin choose not to do so
 		if ( Standard_Source::hide_standard_source_for_image( $image_id ) ) {
-			ISC_Log::log( sprintf( 'ISC\Render\Caption::get() skipped overlay for "own" image ID "%s"', $image_id ) );
+			ISC_Log::log( sprintf( 'skipped overlay for "own" image ID "%s"', $image_id ) );
 			return '';
 		}
 

--- a/includes/settings/sections/miscellaneous.php
+++ b/includes/settings/sections/miscellaneous.php
@@ -72,7 +72,7 @@ class Miscellaneous extends Settings\Section {
 	public function render_field_enable_log() {
 		$options      = $this->get_isc_options();
 		$checked      = ! empty( $options['enable_log'] );
-		$log_file_url = \ISC_Log::get_log_file_URL();
+		$log_file_url = \ISC_Log::get_log_file_url();
 		require_once ISCPATH . '/admin/templates/settings/miscellaneous/log-enable.php';
 	}
 


### PR DESCRIPTION
Extend log entries

The log feature includes more parameters now to digg deeper into potential issues.

- `?isc-log` without a value will log the same information as before 
- `isc-log=content` will log the analyzed content; currently only when indexing the content for the first time
- `isc-log=backtrace` will log file and function backtrace; currently only when using `the_content`
- `isc-clear-log` will clear the log with every page reload
- `isc-ignore-cache` will ignore an existing post-image index, so that ISC analyses the content freshly and one doesn’t need to remove that cache manually in the backend

In addition to these new parameters and minor code improvements, I programmatically added the class and method that causes the log automatically before the log message.