### PR TITLE
Index improvements

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -38,6 +38,8 @@ class ISC_Admin extends ISC_Class {
 		add_action( 'wp_ajax_isc-image-post-relations', [ $this, 'list_image_post_relations' ] );
 		add_action( 'wp_ajax_isc-clear-index', [ $this, 'clear_index' ] );
 		add_action( 'wp_ajax_isc-clear-storage', [ $this, 'clear_storage' ] );
+		add_action( 'wp_ajax_isc-clear-image-posts-index', [ $this, 'clear_image_posts_index' ] );
+		add_action( 'wp_ajax_isc-clear-post-images-index', [ $this, 'clear_post_images_index' ] );
 
 		// add links to setting and source list to plugin page
 		add_action( 'plugin_action_links_' . ISCBASE, [ $this, 'add_links_to_plugin_page' ] );
@@ -410,9 +412,8 @@ class ISC_Admin extends ISC_Class {
 	}
 
 	/**
-	 * List image post relations (called with ajax)
-	 *
-	 * @since 1.6.1
+	 * List post-images (images associated with a specidic post ID)
+	 * Called using AJAX
 	 */
 	public function list_post_image_relations() {
 
@@ -421,6 +422,7 @@ class ISC_Admin extends ISC_Class {
 			'posts_per_page' => - 1,
 			'post_status'    => null,
 			'post_parent'    => null,
+			'post_type'	     => 'any',
 			'meta_query'     => [
 				[
 					'key' => 'isc_post_images',
@@ -508,6 +510,46 @@ class ISC_Admin extends ISC_Class {
 		ISC_Storage_Model::clear_storage();
 
 		die( esc_html__( 'Storage deleted', 'image-source-control-isc' ) );
+	}
+
+	/**
+	 * Callback to clear the isc_image_posts post meta
+	 */
+	public function clear_image_posts_index() {
+		check_ajax_referer( 'isc-admin-ajax-nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			die( 'Wrong capabilities' );
+		}
+
+		if ( ! isset( $_POST['image_id'] ) ) {
+			die( 'No image ID given' );
+		}
+
+		$image_id = (int) $_POST['image_id'];
+		delete_post_meta( $image_id, 'isc_image_posts' );
+
+		die( 'Image-Posts index cleared' );
+	}
+
+	/**
+	 * Callback to clear the isc_post_images post meta
+	 */
+	public function clear_post_images_index() {
+		check_ajax_referer( 'isc-admin-ajax-nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			die( 'Wrong capabilities' );
+		}
+
+		if ( ! isset( $_POST['post_id'] ) ) {
+			die( 'No post ID given' );
+		}
+
+		$post_id = (int) $_POST['post_id'];
+		delete_post_meta( $post_id, 'isc_post_images' );
+
+		die( 'Post-Images index cleared' );
 	}
 
 	/**

--- a/admin/assets/js/sources.js
+++ b/admin/assets/js/sources.js
@@ -130,5 +130,66 @@ jQuery( document ).ready(
 				);
 			}
 		);
-	}
-);
+
+		/**
+		 * Handle image-post index removal
+		 */
+		// Select the parent element that exists when the page loads since the button is added dynamically
+		const isc_image_posts_index_list = document.querySelector('#isc-image-post-relations');
+
+		isc_image_posts_index_list.addEventListener('click', function(event) {
+			if (!event.target || !event.target.matches('.isc-button-delete-image-posts-index')) {
+				return;
+			}
+
+			event.preventDefault();
+			const el = event.target;
+			var image_id = el.dataset.imageId;
+			var request = new XMLHttpRequest();
+
+			el.style.display = 'none';
+
+			request.open('POST', ajaxurl, true);
+			request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+
+			// Remove the row on success
+			request.onload = function() {
+				if (this.status >= 200 && this.status < 400) {
+					el.closest('tr').remove();
+				}
+			};
+
+			request.send('action=isc-clear-image-posts-index&nonce=' + isc.ajaxNonce + '&image_id=' + image_id);
+		});
+
+		/**
+		 * Handle post-images index removal
+		 */
+		// Select the parent element that exists when the page loads since the button is added dynamically
+		const isc_post_images_index_list = document.querySelector('#isc-post-image-relations');
+
+		isc_post_images_index_list.addEventListener('click', function(event) {
+			if (!event.target || !event.target.matches('.isc-button-delete-post-images-index')) {
+				return;
+			}
+
+			event.preventDefault();
+			const el = event.target;
+			var post_id = el.dataset.iscPostId;
+			var request = new XMLHttpRequest();
+
+			el.style.display = 'none';
+
+			request.open('POST', ajaxurl, true);
+			request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+
+			// Remove the row on success
+			request.onload = function() {
+				if (this.status >= 200 && this.status < 400) {
+					el.closest('tr').remove();
+				}
+			};
+
+			request.send('action=isc-clear-post-images-index&nonce=' + isc.ajaxNonce + '&post_id=' + post_id);
+		});
+	} );

--- a/admin/templates/image-posts-list.php
+++ b/admin/templates/image-posts-list.php
@@ -4,41 +4,46 @@
  *
  * @var WP_Query $images_with_posts query with posts that have the "isc_image_posts" post meta.
  */
-if ( $images_with_posts->have_posts() ) : ?>
-	<table class="widefat isc-table isc-table-debug-list" style="width: 80%;" >
-		<thead>
-			<tr>
-				<th><?php esc_html_e( 'Image', 'image-source-control-isc' ); ?></th>
-				<th><?php esc_html_e( 'Posts', 'image-source-control-isc' ); ?></th>
-			</tr>
-		</thead><tbody>
-		<?php
-
-		while ( $images_with_posts->have_posts() ) :
-			$images_with_posts->the_post();
-			$_posts = get_post_meta( get_the_ID(), 'isc_image_posts', true );
-			if ( is_array( $_posts ) && count( $_posts ) > 0 ) :
-				?>
+?>
+<table class="widefat isc-table isc-table-debug-list" style="width: 80%;" >
+	<thead>
 		<tr>
-			<td>
-				<?php edit_post_link( get_the_title(), '', '', get_the_ID() ); ?>
-			</td>
-			<td>
-					<ul>
-					<?php
-					foreach ( $_posts as $_post_id ) :
-						// skip if this is a revision.
-						if ( wp_is_post_revision( $_post_id ) ) {
-							continue;
-						}
-						?>
-						<li><a href="<?php echo esc_url( get_edit_post_link( $_post_id ) ); ?>"><?php echo esc_html( get_the_title( $_post_id ) ); ?></a></li>
-					<?php endforeach; ?>
-					</ul>
-		   </td>
+			<th><?php esc_html_e( 'Image', 'image-source-control-isc' ); ?></th>
+			<th><?php esc_html_e( 'Posts', 'image-source-control-isc' ); ?></th>
+			<th><?php esc_html_e( 'Actions', 'image-source-control-isc' ); ?></th>
 		</tr>
-		<?php endif; ?>
-		<?php endwhile; ?>
-	</tbody></table>
+	</thead><tbody>
 	<?php
-endif;
+
+	while ( $images_with_posts->have_posts() ) :
+		$images_with_posts->the_post();
+		$_posts = get_post_meta( get_the_ID(), 'isc_image_posts', true );
+		if ( is_array( $_posts ) && count( $_posts ) > 0 ) :
+			?>
+	<tr>
+		<td>
+			<?php edit_post_link( get_the_title(), '', '', get_the_ID() ); ?>
+		</td>
+		<td>
+				<ul>
+				<?php
+				foreach ( $_posts as $_post_id ) :
+					// skip if this is a revision.
+					if ( wp_is_post_revision( $_post_id ) ) {
+						continue;
+					}
+					?>
+					<li><a href="<?php echo esc_url( get_edit_post_link( $_post_id ) ); ?>"><?php echo esc_html( get_the_title( $_post_id ) ); ?></a></li>
+				<?php endforeach; ?>
+				</ul>
+		</td>
+		<td>
+			<button type="button" class="button isc-button-delete-image-posts-index" data-image-id="<?php echo absint( get_the_ID() ); ?>">
+				<?php esc_html_e( 'Delete', 'image-source-control-isc' ); ?>
+			</button>
+		</td>
+	</tr>
+	<?php endif; ?>
+	<?php endwhile; ?>
+</tbody></table>
+<?php

--- a/admin/templates/post-images-list.php
+++ b/admin/templates/post-images-list.php
@@ -4,40 +4,45 @@
  *
  * @var WP_Query $posts_with_images query with posts that have the "isc_post_images" post meta.
  */
-if ( $posts_with_images->have_posts() ) : ?>
-	<table class="widefat isc-table isc-table-debug-list" style="width: 80%;" >
-		<thead>
-			<tr>
-				<th><?php esc_html_e( 'Post / Page', 'image-source-control-isc' ); ?></th>
-				<th><?php esc_html_e( 'Images', 'image-source-control-isc' ); ?></th>
-			</tr>
-		</thead><tbody>
-		<?php
-
-		while ( $posts_with_images->have_posts() ) :
-			$posts_with_images->the_post();
-			$_images = get_post_meta( get_the_ID(), 'isc_post_images', true );
-			if ( is_array( $_images ) && count( $_images ) > 0 ) :
-				?>
+?>
+<table class="widefat isc-table isc-table-debug-list" style="width: 80%;" >
+	<thead>
 		<tr>
-			<td><a href="<?php echo esc_url( get_edit_post_link( get_the_ID() ) ); ?>"><?php the_title(); ?></a></td>
-			<td>
-					<ul>
-					<?php
-					foreach ( $_images as $_image_id => $_image_url ) :
-						?>
-						<li><?php if ( $_image_id ) : ?>
-							<?php edit_post_link( esc_html( get_the_title( $_image_id ) ), '', '', $_image_id ); ?>
-						</li>
-						<?php else : ?>
-							<?php print_r( $_images ); ?>
-						<?php endif; ?>
-					<?php endforeach; ?>
-					</ul>
-			</td>
+			<th><?php esc_html_e( 'Post / Page', 'image-source-control-isc' ); ?></th>
+			<th><?php esc_html_e( 'Images', 'image-source-control-isc' ); ?></th>
+			<th><?php esc_html_e( 'Actions', 'image-source-control-isc' ); ?></th>
 		</tr>
-		<?php endif; ?>
-		<?php endwhile; ?>
-	</tbody></table>
+	</thead><tbody>
 	<?php
-endif;
+
+	while ( $posts_with_images->have_posts() ) :
+		$posts_with_images->the_post();
+		$_images = get_post_meta( get_the_ID(), 'isc_post_images', true );
+		if ( is_array( $_images ) && count( $_images ) > 0 ) :
+			?>
+	<tr>
+		<td><a href="<?php echo esc_url( get_edit_post_link( get_the_ID() ) ); ?>"><?php the_title(); ?></a></td>
+		<td>
+				<ul>
+				<?php
+				foreach ( $_images as $_image_id => $_image_url ) :
+					?>
+					<li><?php if ( $_image_id ) : ?>
+						<?php edit_post_link( esc_html( get_the_title( $_image_id ) ), '', '', $_image_id ); ?>
+					</li>
+					<?php else : ?>
+						<?php print_r( $_images ); ?>
+					<?php endif; ?>
+				<?php endforeach; ?>
+				</ul>
+		</td>
+		<td>
+			<button type="button" class="button isc-button-delete-post-images-index" data-isc-post-id="<?php echo absint( get_the_ID() ); ?>">
+				<?php esc_html_e( 'Delete', 'image-source-control-isc' ); ?>
+			</button>
+		</td>
+	</tr>
+	<?php endif; ?>
+	<?php endwhile; ?>
+</tbody></table>
+<?php

--- a/admin/templates/sources/post-index.php
+++ b/admin/templates/sources/post-index.php
@@ -34,11 +34,16 @@
 </table>
 <p><?php esc_html_e( 'The following options allow you to see if ISC was able to detect all images.', 'image-source-control-isc' ); ?></p>
 <button id="isc-list-post-image-relation" class="button button-secondary"><?php esc_html_e( 'list post-image relations', 'image-source-control-isc' ); ?></button>
-<p class="description"><?php esc_html_e( 'A list of posts and the images in them.', 'image-source-control-isc' ); ?></p>
+<p class="description"><?php esc_html_e( 'A list of posts and the images in them.', 'image-source-control-isc' ); ?>
+	<?php esc_html_e( 'This index is used to generate the Per-post List.', 'image-source-control-isc' ); ?>
+	<?php esc_html_e( 'Delete an entry to re-index a specific post.', 'image-source-control-isc' ); ?>
+</p>
 <div id="isc-post-image-relations"></div>
 <hr/>
 <button id="isc-list-image-post-relation" class="button button-secondary"><?php esc_html_e( 'list image-post relations', 'image-source-control-isc' ); ?></button>
-<p class="description"><?php esc_html_e( 'A list of images and the posts they appear in.', 'image-source-control-isc' ); ?></p>
+<p class="description"><?php esc_html_e( 'A list of images and the posts they appear in.', 'image-source-control-isc' ); ?>
+	<?php esc_html_e( 'This index is used to generate the Global List.', 'image-source-control-isc' ); ?>
+</p>
 <div id="isc-image-post-relations"></div>
 <hr/>
 <button id="isc-clear-index" class="button button-secondary"><?php esc_html_e( 'clear image-post index', 'image-source-control-isc' ); ?></button>

--- a/includes/model.php
+++ b/includes/model.php
@@ -69,7 +69,6 @@ class ISC_Model {
 	 *
 	 * @param integer $post_id ID of the target post.
 	 * @param array   $image_ids IDs of the attachments in the content.
-	 * @todo move into ISC\Image_Post_Index
 	 */
 	public static function update_image_posts_meta( $post_id, $image_ids ) {
 		ISC_Log::log( 'enter update_image_posts_meta()' );


### PR DESCRIPTION
Due to an issue on one user’s site that I couldn’t reproduce, I extended the lists with the post-images and image-posts index to allow deleting individual entries.

While doing so, I improved a few more things:

- The post-images list did only list posts, not other post types and now lists all of them, if relevant.
- added more log entries to the `update_image_posts_meta()` function.
- extended the explanation for the various indizes.