### PR TITLE
Critical PHP error for wrong value

### DIFF
--- a/public/public.php
+++ b/public/public.php
@@ -487,7 +487,7 @@ class ISC_Public extends ISC_Class {
 		$attachments      = get_post_meta( $post_id, 'isc_post_images', true );
 		$exclude_standard = Standard_Source::standard_source_is( 'exclude' );
 
-		if ( ! empty( $attachments ) ) {
+		if ( ! empty( $attachments ) && is_array( $attachments ) ) {
 			ISC_Log::log( sprintf( 'going through %d attachments', count( $attachments ) ) );
 			$atts = [];
 			foreach ( $attachments as $attachment_id => $attachment_array ) {


### PR DESCRIPTION
A user reported a critical error with `$attachments` not being empty or an array. While I am not sure how this could happen, I extended the check to no longer cause that error.