### PR TITLE
Size label

### DIFF
--- a/admin/templates/settings/global-list/thumbnail-enable.php
+++ b/admin/templates/settings/global-list/thumbnail-enable.php
@@ -4,6 +4,7 @@
  *
  * @var array $options ISC options.
  * @var array $sizes available sizes for images.
+ * @var array $sizes_labels translatable labels for the sizes.
  */
 ?>
 <label>
@@ -14,7 +15,7 @@
 	<?php foreach ( $sizes as $_name => $_sizes ) : ?>
 		<option value="<?php echo esc_html( $_name ); ?>" <?php selected( $_name, $options['thumbnail_size'] ); ?>>
 			<?php
-			echo esc_html( $_name );
+			echo isset( $sizes_labels[ $_name ] ) ? esc_html( $sizes_labels[ $_name ] ) : esc_html( $_name );
 			if ( is_array( $_sizes ) && isset( $_sizes['width'] ) && isset( $_sizes['height'] ) ) :
 				echo esc_html( sprintf( ' (%1$dx%2$d)', $_sizes['width'], $_sizes['height'] ) );
 			endif;

--- a/includes/isc.class.php
+++ b/includes/isc.class.php
@@ -50,7 +50,7 @@ class ISC_Class {
 		 *
 		 * @var array available thumbnail sizes.
 		 */
-		protected $thumbnail_size = array( 'thumbnail', 'medium', 'large', 'custom' );
+		protected $thumbnail_size = [ 'thumbnail', 'medium', 'large', 'custom' ];
 
 		/**
 		 * Options saved in the db

--- a/includes/settings/sections/global-list.php
+++ b/includes/settings/sections/global-list.php
@@ -59,8 +59,14 @@ class Global_List extends Settings\Section {
 	 * Render option to display thumbnails in the Global list
 	 */
 	public function render_field_thumbnail_in_list() {
-		$options = $this->get_isc_options();
-		$sizes   = [];
+		$options      = $this->get_isc_options();
+		$sizes        = [];
+		$sizes_labels = [
+			'thumbnail' => _x( 'Thumbnail', 'image size label', 'image-source-control-isc' ),
+			'medium'    => _x( 'Medium', 'image size label', 'image-source-control-isc' ),
+			'large'     => _x( 'Large', 'image size label', 'image-source-control-isc' ),
+			'custom'    => _x( 'Custom', 'image size label', 'image-source-control-isc' ),
+		];
 
 		// convert the sizes array to match key and value
 		foreach ( $this->thumbnail_size as $_size ) {

--- a/includes/settings/sections/global-list.php
+++ b/includes/settings/sections/global-list.php
@@ -67,15 +67,12 @@ class Global_List extends Settings\Section {
 			$sizes[ $_size ] = $_size;
 		}
 
-		// requires WP 5.3
-		if ( function_exists( 'wp_get_registered_image_subsizes' ) ) {
-			// go through sizes we consider for thumbnails and get their current sizes as set up in WordPress
-			$wp_image_sizes = wp_get_registered_image_subsizes();
-			if ( is_array( $wp_image_sizes ) ) {
-				foreach ( $wp_image_sizes as $_name => $_sizes ) {
-					if ( isset( $sizes[ $_name ] ) ) {
-						$sizes[ $_name ] = $_sizes;
-					}
+		// go through sizes we consider for thumbnails and get their current sizes as set up in WordPress
+		$wp_image_sizes = wp_get_registered_image_subsizes();
+		if ( is_array( $wp_image_sizes ) ) {
+			foreach ( $wp_image_sizes as $_name => $_sizes ) {
+				if ( isset( $sizes[ $_name ] ) ) {
+					$sizes[ $_name ] = $_sizes;
 				}
 			}
 		}


### PR DESCRIPTION
- made thumbnail size labels in the Global List options translatable
- removed a check for WP 5.3