### PR TITLE
Ignore long URL strings

### DIFF
--- a/includes/model.php
+++ b/includes/model.php
@@ -577,6 +577,12 @@ class ISC_Model {
 			return 0;
 		}
 
+		// ignore src strings with more than 1000 characters; these could be base24 images not hosted in WordPress
+		if ( strlen( $url ) > 1000 ) {
+			ISC_Log::log( 'exit due to URL length' );
+			return 0;
+		}
+
 		// get the file extension, e.g. "jpg"
 		$ext = pathinfo( $url, PATHINFO_EXTENSION );
 		if ( ! $ext ) {


### PR DESCRIPTION
A user reported that ISC ran the SQL query for a URL with 110,000 characters (!). It was a base64 encoded image. I don’t want to fully ignore this image format for now and so only restricted the check for a healthy 1000 char length.