### PR TITLE
Prepare to use the WP caption as standard source

### DIFF
--- a/admin/templates/settings/miscellaneous/standard-source.php
+++ b/admin/templates/settings/miscellaneous/standard-source.php
@@ -28,6 +28,17 @@
 	<?php if ( ! \ISC\Plugin::is_pro() ) : ?>
 		<br/>
 		<label>
+			<input type="radio" name="isc_options[standard_source]" <?php checked( $standard_source, 'wp_caption' ); ?> disabled/>
+			<?php echo ISC_Admin::get_pro_link( 'standard-source-caption' ); ?>
+			<?php esc_html_e( 'Caption', 'image-source-control-isc' ); ?>
+		</label>
+	<p class="description">
+		<?php
+		esc_html_e( 'Use the caption entered in the media library.', 'image-source-control-isc' );
+		?>
+	</p>
+		<br/>
+		<label>
 			<input type="radio" name="isc_options[standard_source]" <?php checked( $standard_source, 'iptc' ); ?> disabled/>
 			<?php echo ISC_Admin::get_pro_link( 'standard-source-iptc' ); ?>
 			<?php esc_html_e( 'IPTC meta data', 'image-source-control-isc' ); ?>

--- a/includes/standard-source.php
+++ b/includes/standard-source.php
@@ -123,18 +123,19 @@ class Standard_Source {
 	 * @return string
 	 */
 	public static function get_standard_source_label( string $value = null ) {
-		$labels = array(
+		$labels = [
 			'exclude'     => __( 'Exclude from lists', 'image-source-control-isc' ),
 			'author_name' => __( 'Author name', 'image-source-control-isc' ),
+			'wp_caption'  => __( 'Caption', 'image-source-control-isc' ),
 			'custom_text' => __( 'Custom text', 'image-source-control-isc' ),
 			'iptc'        => __( 'IPTC meta data', 'image-source-control-isc' ),
-		);
+		];
 
 		if ( ! $value ) {
 			$value = self::get_standard_source();
 		}
 
-		return $labels[ $value ] ?? '';
+		return $labels[ $value ] ?? $value;
 	}
 
 	/**

--- a/tests/functional/pro/includes/Caption_Standard_Cest.php
+++ b/tests/functional/pro/includes/Caption_Standard_Cest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace ISC\Tests\Functional;
+
+/**
+ * Test ISC\Pro\WP_Caption
+ */
+class Caption_Standard_Cest {
+
+	public function _before(\FunctionalTester $I) {
+		// enable the overlay
+		$existingOption = $I->grabOptionFromDatabase('isc_options');
+		$existingOption['display_type'] = ['overlay'];
+		// Make sure we enable the "iptc" standard source
+		$existingOption['standard_source'] = 'wp_caption';
+		// Show the standard source if the image’s specific source is empty
+		$existingOption['use_standard_source_by_default'] = 1;
+
+		// Update the option in the database with the new array.
+		$I->haveOptionInDatabase( 'isc_options', $existingOption );
+
+		// prepare an image
+		$I->havePostInDatabase( [
+           'ID' => 123,
+           'post_title' => 'Image One',
+           'guid' => 'https://example.com/image-one.jpg',
+           'post_excerpt' => 'This is the caption',
+       ] );
+	}
+
+	/**
+	 * Setup:
+	 * - image has no source
+	 * - image is set to use the standard source
+	 *
+	 * @param \FunctionalTester $I
+	 *
+	 * @return void
+	 */
+	public function test_image_standard_source_shows_wp_caption( \FunctionalTester $I ) {
+		$I->havePageInDatabase( [
+			'post_name'    => 'test-page',
+			'post_content' => '<img src="https://example.com/image-one.jpg" />',
+		] );
+
+		// Go to the page.
+		$I->amOnPage( '/test-page' );
+		$I->seeInSource( '<span id="isc_attachment_123" class="isc-source "><img decoding="async" src="https://example.com/image-one.jpg" /><span class="isc-source-text">Quelle: This is the caption</span></span>' );
+	}
+}


### PR DESCRIPTION
The feature to pull the image caption entered in the media library, which is part of WordPress core, as the standard source. The feature is part of Pro.