### PR TITLE
Limit pretext preview to text

### DIFF
--- a/admin/templates/settings/preview/caption-preview.html
+++ b/admin/templates/settings/preview/caption-preview.html
@@ -42,7 +42,7 @@
 </div>
 <script>
 	document.getElementById('preview_image').src = './../../../../admin/templates/settings/preview/image-for-position-preview.jpg';
-	document.querySelector('.isc-source-text').innerHTML = caption_pretext + 'Jane Doe';
+	document.querySelector('.isc-source-text').textContent = caption_pretext + 'Jane Doe';
 </script>
 </body>
 </html>


### PR DESCRIPTION
Limit the pretext for the caption preview in the backend to text only to prevent XSS attacks with manipulated links that could be executed by admin users.