### PR TITLE
Prevent JS error on list view

### DIFF
--- a/admin/includes/media-library-filter.php
+++ b/admin/includes/media-library-filter.php
@@ -2,6 +2,8 @@
 
 namespace ISC\Admin;
 
+use ISC\Admin_Utils;
+
 /**
  * Add a filter field to the Media Library view.
  */
@@ -18,7 +20,7 @@ class Media_Library_Filter {
 	 * Add a filter to the Media Library list view.
 	 */
 	public function add_media_library_filter() {
-		self::is_media_library_list_view_page();
+		Admin_Utils::is_media_library_list_view_page();
 
 		$filters = apply_filters( 'isc_admin_media_library_filters', [] );
 
@@ -30,28 +32,5 @@ class Media_Library_Filter {
 		$filter_current = isset( $_GET['isc_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['isc_filter'] ) ) : '';
 
 		include ISCPATH . '/admin/templates/media-library-filter.php';
-	}
-
-	/**
-	 * Return true if we are on the media library page in list view
-	 *
-	 * @return bool
-	 */
-	public static function is_media_library_list_view_page(): bool {
-		if ( ! is_admin() || ! function_exists( 'get_current_screen' ) ) {
-			return false;
-		}
-
-		$screen = get_current_screen();
-		if ( ! isset( $screen->id ) || $screen->id !== 'upload' ) {
-			return false;
-		}
-
-		// don’t show this in grid mode
-		if ( 'list' !== get_user_option( 'media_library_mode' ) ) {
-			return false;
-		}
-
-		return true;
 	}
 }

--- a/admin/utils.php
+++ b/admin/utils.php
@@ -33,6 +33,29 @@ trait Admin_Utils {
 	}
 
 	/**
+	 * Return true if we are on the media library page in list view
+	 *
+	 * @return bool
+	 */
+	public static function is_media_library_list_view_page(): bool {
+		if ( ! is_admin() || ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
+		$screen = get_current_screen();
+		if ( ! isset( $screen->id ) || $screen->id !== 'upload' ) {
+			return false;
+		}
+
+		// don’t show this in grid mode
+		if ( 'list' !== get_user_option( 'media_library_mode' ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Get URL to the ISC website by site language
 	 *
 	 * @param string $url_param    Default parameter added to the main URL, leading to https://imagesourceocontrol.com/.

--- a/includes/image-sources/admin/media-library-filters.php
+++ b/includes/image-sources/admin/media-library-filters.php
@@ -2,7 +2,7 @@
 
 namespace ISC\Image_Sources;
 
-use ISC\Admin\Media_Library_Filter;
+use ISC\Admin_Utils;
 
 /**
  * Handle filters in the Media Library
@@ -44,7 +44,7 @@ class Admin_Media_Library_Filters {
 	 * @param \WP_Query $query The current query.
 	 */
 	public function filter_media_library( \WP_Query $query ) {
-		Media_Library_Filter::is_media_library_list_view_page();
+		Admin_Utils::is_media_library_list_view_page();
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$filter = isset( $_GET['isc_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['isc_filter'] ) ) : '';
@@ -125,7 +125,7 @@ class Admin_Media_Library_Filters {
 	 * Display an admin notice if the Image Sources column is not enabled in list view.
 	 */
 	public function check_and_display_admin_notice() {
-		Media_Library_Filter::is_media_library_list_view_page();
+		Admin_Utils::is_media_library_list_view_page();
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$filter = isset( $_GET['isc_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['isc_filter'] ) ) : '';

--- a/includes/image-sources/admin/scripts.php
+++ b/includes/image-sources/admin/scripts.php
@@ -30,6 +30,11 @@ class Image_Sources_Admin_Scripts {
 			wp_enqueue_script( 'isc_sources_script', ISCBASEURL . '/admin/assets/js/sources.js', [], ISCVERSION, true );
 		}
 
+		// check if we are on the media library page with list view
+		if ( Admin_Utils::is_media_library_list_view_page() ) {
+			return;
+		}
+
 		if ( in_array( $screen->id, [ 'upload', 'widgets', 'customize' ], true ) ) {
 			wp_enqueue_script( 'isc_attachment_compat', ISCBASEURL . '/admin/assets/js/wp.media.view.AttachmentCompat.js', [ 'media-upload' ], ISCVERSION, true );
 		}


### PR DESCRIPTION
The media library list view showed an error message about missing `wp.media.view` which is indeed not available in that view.

I made the method `Admin_Utils::is_media_library_list_view_page()` more available and used it to prevent the relevant script on that view type.