### PR TITLE
Add support for AVIF files

### DIFF
--- a/includes/image-sources/image-sources.php
+++ b/includes/image-sources/image-sources.php
@@ -48,6 +48,7 @@ class Image_Sources {
 		'gif',
 		'jpeg',
 		'webp',
+		'avif',
 	];
 
 	/**


### PR DESCRIPTION
The AVIF image extension is not recognized when looking for image sources.