### PR TITLE
Test new extract methods

### DIFF
--- a/includes/image-sources/analyze-html.php
+++ b/includes/image-sources/analyze-html.php
@@ -167,7 +167,7 @@ class Analyze_HTML {
 		// merge matches from both conditions and remove empty ones
 		$urls = array_filter( array_merge( $matches[1], $matches[6] ) );
 		// remove duplicate URLs
-		return array_unique( $urls );
+		return array_values( array_unique( $urls ) );
 	}
 
 	/**
@@ -196,15 +196,18 @@ class Analyze_HTML {
 		 * - Followed by one or more non-whitespace characters (non-greedy)
 		 * - Ending with a dot and one of the allowed extensions (case-insensitive)
 		 * - Optionally followed by a query string
-		 * - The URL is expected to end before a closing quote or whitespace.
+		 * - The URL is expected to be wrapped in either:
+		 * -- single or double quotes
+		 * -- whitespace
+		 * -- brackets "()"
 		 */
-		$pattern = '#https?://\S+?\.(?:' . $types . ')(?:\?\S*)?(?=["\'\s])#i';
+		$pattern = '#https?://\S+?\.(?:' . $types . ')(?:\?\S*)?(?=["\'\s\)])#i';
 
 		preg_match_all( $pattern, $html, $matches );
 
 		if ( ! empty( $matches[0] ) ) {
 			// Remove duplicate URLs.
-			$urls = array_unique( $matches[0] );
+			return array_values( array_unique( $matches[0] ) );
 		}
 
 		return $urls;

--- a/tests/wpunit/includes/Image_Sources/Analyze_HTML/Extract_Image_Urls_From_Html_Tags_Test.php
+++ b/tests/wpunit/includes/Image_Sources/Analyze_HTML/Extract_Image_Urls_From_Html_Tags_Test.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace ISC\Tests\WPUnit\Includes\Image_Sources\Analyze_HTML;
+
+use ISC\Image_Sources\Analyze_HTML;
+use ISC\Tests\WPUnit\WPTestCase;
+use ISC\Image_Sources\Image_Sources;
+
+/**
+ * Test if ISC/Analyze_HTML:extract_image_urls_from_html_tags() works as expected.
+ */
+class Extract_Image_Urls_From_Html_Tags_Test extends WPTestCase {
+
+	/**
+	 * Helper to extract information from HTML
+	 *
+	 * @var Analyze_HTML
+	 */
+	public $html_analyzer;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->html_analyzer = new Analyze_HTML();
+
+		// Mock the allowed_extensions property in Image_Sources
+		$image_sources                     = $this->getMockBuilder( Image_Sources::class )
+		                                          ->disableOriginalConstructor()
+		                                          ->getMock();
+		$image_sources->allowed_extensions = [ 'jpg', 'jpeg', 'png', 'gif', 'webp' ];
+
+		// Use reflection to set the singleton instance
+		$reflection        = new \ReflectionClass( Image_Sources::class );
+		$instance_property = $reflection->getProperty( 'instance' );
+		$instance_property->setAccessible( true );
+		$instance_property->setValue( null, $image_sources );
+	}
+
+	/**
+	 * Test if the function returns an array with empty input
+	 */
+	public function test_empty_input() {
+		$html   = '';
+		$result = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( [], $result, 'extract_image_urls_from_html_tags should return an empty array for empty input' );
+		$this->assertIsArray( $result, 'extract_image_urls_from_html_tags should return an array' );
+	}
+
+	/**
+	 * Test with HTML containing no images
+	 */
+	public function test_no_images() {
+		$html   = '<p>This is a paragraph with no images.</p>';
+		$result = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( [], $result, 'extract_image_urls_from_html_tags should return an empty array when no images are present' );
+	}
+
+	/**
+	 * Test with a simple image tag
+	 */
+	public function test_simple_image_tag() {
+		$html     = '<img src="https://example.com/image.jpg">';
+		$expected = [ 'https://example.com/image.jpg' ];
+		$result   = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( $expected, $result, 'extract_image_urls_from_html_tags did not extract the correct URL from a simple image tag' );
+	}
+
+	/**
+	 * Test with multiple image tags
+	 */
+	public function test_multiple_image_tags() {
+		$html     = '<img src="https://example.com/image1.jpg"><img src="https://example.com/image2.png">';
+		$expected = [ 'https://example.com/image1.jpg', 'https://example.com/image2.png' ];
+		$result   = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( $expected, $result, 'extract_image_urls_from_html_tags did not extract all URLs from multiple image tags' );
+	}
+
+	/**
+	 * Test with image tags and other URLs in the HTML
+	 */
+	public function test_mixed_content() {
+		$html     = '<p>Text with a <a href="https://example.com">link</a> and an <img src="https://example.com/image.jpg"> image.</p>';
+		$expected = [ 'https://example.com/image.jpg' ];
+		$result   = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( $expected, $result, 'extract_image_urls_from_html_tags should only extract image URLs' );
+	}
+
+	/**
+	 * Test with image URLs in CSS background
+	 */
+	public function test_css_background_image() {
+		$html     = '<div style="background-image: url(https://example.com/background.jpg)"></div>';
+		$expected = [ 'https://example.com/background.jpg' ];
+		$result   = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( $expected, $result, 'extract_image_urls_from_html_tags should extract URLs from CSS background images' );
+	}
+
+	/**
+	 * Test with image URLs in srcset attribute
+	 */
+	public function test_srcset_attribute() {
+		$html     = '<img src="https://example.com/image.jpg" srcset="https://example.com/image-small.jpg 300w, https://example.com/image-large.jpg 1200w">';
+		$expected = [ 'https://example.com/image.jpg' ];
+		$result   = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( $expected, $result, 'extract_image_urls_from_html_tags should not extract URLs from srcset attribute' );
+	}
+
+	/**
+	 * Test with image URLs with query parameters
+	 */
+	public function test_urls_with_query_parameters() {
+		$html     = '<img src="https://example.com/image.jpg?width=300&height=200">';
+		$expected = [ 'https://example.com/image.jpg?width=300&height=200' ];
+		$result   = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( $expected, $result, 'extract_image_urls_from_html_tags should extract URLs with query parameters' );
+	}
+
+	/**
+	 * Test with image URLs with no file extension
+	 */
+	public function test_urls_without_extension() {
+		$html     = '<img src="https://example.com/image">';
+		$expected = [ 'https://example.com/image' ];
+		$result   = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( $expected, $result, 'extract_image_urls_from_html_tags should extract URLs without file extensions from img tags' );
+	}
+
+	/**
+	 * Test with duplicate image URLs
+	 */
+	public function test_duplicate_urls() {
+		$html     = '<img src="https://example.com/image.jpg"><img src="https://example.com/image.jpg">';
+		$expected = [ 'https://example.com/image.jpg' ];
+		$result   = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( $expected, $result, 'extract_image_urls_from_html_tags should return unique URLs' );
+	}
+
+	/**
+	 * Test with complex HTML structure
+	 */
+	public function test_complex_html() {
+		$html     = '
+            <div class="container">
+                <figure class="wp-block-image">
+                    <a href="https://example.com">
+                        <img src="https://example.com/figure-image.jpg" alt="Figure image">
+                    </a>
+                </figure>
+                <p>Some text with <img src="https://example.com/inline-image.png"> inline image.</p>
+                <div style="background-image: url(https://example.com/background.webp)"></div>
+            </div>
+        ';
+		$expected = [
+			'https://example.com/figure-image.jpg',
+			'https://example.com/inline-image.png',
+			'https://example.com/background.webp'
+		];
+		$result   = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		sort( $expected );
+		sort( $result );
+		$this->assertEquals( $expected, $result, 'extract_image_urls_from_html_tags did not extract all URLs from complex HTML' );
+	}
+
+	/**
+	 * Test with relative URLs
+	 */
+	public function test_relative_urls() {
+		$html     = '<img src="/images/relative.jpg">';
+		$expected = ['/images/relative.jpg'];
+		$result   = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( $expected, $result, 'extract_image_urls_from_html_tags should not extract relative URLs' );
+	}
+
+	/**
+	 * Test with malformed HTML
+	 */
+	public function test_malformed_html() {
+		$html     = '<img src="https://example.com/image.jpg" <p>Broken HTML</p>';
+		$expected = [ 'https://example.com/image.jpg' ];
+		$result   = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( $expected, $result, 'extract_image_urls_from_html_tags should handle malformed HTML' );
+	}
+
+	/**
+	 * Test with URLs that don't have allowed extensions. They are accepted in src attributes.
+	 */
+	public function test_non_image_extensions_in_src() {
+		$html     = '<img src="https://example.com/document.pdf">';
+		$expected = ['https://example.com/document.pdf'];
+		$result   = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( $expected, $result, 'extract_image_urls_from_html_tags should not extract URLs with non-image extensions' );
+	}
+
+	/**
+	 * Test with URLs that don't have allowed extensions. They are not accepted outside of src attributes.
+	 */
+	public function test_non_image_extensions_outside_src() {
+		$html     = '<img data-some="https://example.com/document.pdf">';
+		$expected = [];
+		$result   = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( $expected, $result, 'extract_image_urls_from_html_tags should not extract URLs with non-image extensions' );
+	}
+
+	/**
+	 * Test with invalid URLs in the src attribute.
+	 * This is a known limitation and fixed in Pro.
+	 */
+	public function test_invalid_url_in_src() {
+		$html     = '<img src="data:base" src="https://example.com/image.png">';
+		$expected = ['data:base'];
+		$result   = Analyze_HTML::extract_image_urls_from_html_tags( $html );
+		$this->assertEquals( $expected, $result, 'extract_image_urls_from_html_tags should not extract URLs with non-image extensions' );
+	}
+}

--- a/tests/wpunit/includes/Image_Sources/Analyze_HTML/Extract_Image_Urls_Test.php
+++ b/tests/wpunit/includes/Image_Sources/Analyze_HTML/Extract_Image_Urls_Test.php
@@ -1,0 +1,317 @@
+<?php
+
+namespace ISC\Tests\WPUnit\Includes\Image_Sources\Analyze_HTML;
+
+use ISC\Image_Sources\Analyze_HTML;
+use ISC\Tests\WPUnit\WPTestCase;
+use ISC\Image_Sources\Image_Sources;
+
+/**
+ * Test if ISC/Analyze_HTML:extract_image_urls() works as expected.
+ */
+class Extract_Image_Urls_Test extends WPTestCase {
+
+	/**
+	 * Helper to extract information from HTML
+	 *
+	 * @var Analyze_HTML
+	 */
+	public $html_analyzer;
+
+	public function setUp() : void {
+		parent::setUp();
+		$this->html_analyzer = new Analyze_HTML();
+
+		// Mock the allowed_extensions property in Image_Sources
+		$image_sources = $this->getMockBuilder(Image_Sources::class)
+		                      ->disableOriginalConstructor()
+		                      ->getMock();
+		$image_sources->allowed_extensions = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+
+		// Use reflection to set the singleton instance
+		$reflection = new \ReflectionClass(Image_Sources::class);
+		$instance_property = $reflection->getProperty('instance');
+		$instance_property->setAccessible(true);
+		$instance_property->setValue(null, $image_sources);
+	}
+
+	/**
+	 * Test if the function returns an array with empty input
+	 */
+	public function test_empty_input() {
+		$html = '';
+		$result = Analyze_HTML::extract_image_urls($html);
+		$this->assertEquals([], $result, 'extract_image_urls should return an empty array for empty input');
+		$this->assertIsArray($result, 'extract_image_urls should return an array');
+	}
+
+	/**
+	 * Test with HTML containing no images
+	 */
+	public function test_no_images() {
+		$html = '<p>This is a paragraph with no images.</p>';
+		$result = Analyze_HTML::extract_image_urls($html);
+		$this->assertEquals([], $result, 'extract_image_urls should return an empty array when no images are present');
+	}
+
+	/**
+	 * Test with a simple image tag
+	 */
+	public function test_simple_image_tag() {
+		$html = '<img src="https://example.com/image.jpg">';
+		$expected = ['https://example.com/image.jpg'];
+		$result = Analyze_HTML::extract_image_urls($html);
+		$this->assertEquals($expected, $result, 'extract_image_urls did not extract the correct URL from a simple image tag');
+	}
+
+	/**
+	 * Test with multiple image URLs
+	 */
+	public function test_multiple_image_urls() {
+		$html = '<img src="https://example.com/image1.jpg"><img src="https://example.com/image2.png">';
+		$expected = ['https://example.com/image1.jpg', 'https://example.com/image2.png'];
+		$result = Analyze_HTML::extract_image_urls($html);
+		$this->assertEquals($expected, $result, 'extract_image_urls did not extract all URLs from multiple image tags');
+	}
+
+	/**
+	 * Test with image URLs in various HTML attributes
+	 */
+	public function test_urls_in_various_attributes() {
+		$html = '
+            <a href="https://example.com/image.jpg">Link to image</a>
+            <div data-background="https://example.com/background.png"></div>
+            <source srcset="https://example.com/image.webp">
+        ';
+		$expected = [
+			'https://example.com/image.jpg',
+			'https://example.com/background.png',
+			'https://example.com/image.webp'
+		];
+		$result = Analyze_HTML::extract_image_urls($html);
+		sort($expected);
+		sort($result);
+		$this->assertEquals($expected, $result, 'extract_image_urls should extract image URLs from various HTML attributes');
+	}
+
+	/**
+	 * Test with image URLs in CSS with quotes
+	 */
+	public function test_urls_in_css_with_quotes() {
+		$html = '<style>
+            .background { background-image: url("https://example.com/background.jpg"); }
+            .another { background: url("https://example.com/another.png") no-repeat; }
+        </style>';
+		$expected = [
+			'https://example.com/background.jpg',
+			'https://example.com/another.png'
+		];
+		$result = Analyze_HTML::extract_image_urls($html);
+		sort($expected);
+		sort($result);
+		$this->assertEquals($expected, $result, 'extract_image_urls should extract image URLs from CSS with quotes');
+	}
+
+	/**
+	 * Test with image URLs with query parameters
+	 */
+	public function test_urls_with_query_parameters() {
+		$html = '<img src="https://example.com/image.jpg?width=300&height=200">';
+		$expected = ['https://example.com/image.jpg?width=300&height=200'];
+		$result = Analyze_HTML::extract_image_urls($html);
+		$this->assertEquals($expected, $result, 'extract_image_urls should extract URLs with query parameters');
+	}
+
+	/**
+	 * Test with URLs that don't have allowed extensions
+	 */
+	public function test_non_image_extensions() {
+		$html = '<a href="https://example.com/document.pdf">Document</a>';
+		$expected = [];
+		$result = Analyze_HTML::extract_image_urls($html);
+		$this->assertEquals($expected, $result, 'extract_image_urls should not extract URLs with non-image extensions');
+	}
+
+	/**
+	 * Test with duplicate image URLs
+	 */
+	public function test_duplicate_urls() {
+		$html = '<img src="https://example.com/image.jpg"><img src="https://example.com/image.jpg">';
+		$expected = ['https://example.com/image.jpg'];
+		$result = Analyze_HTML::extract_image_urls($html);
+		$this->assertEquals($expected, $result, 'extract_image_urls should return unique URLs');
+	}
+
+	/**
+	 * Test with URLs in srcset attribute
+	 */
+	public function test_srcset_attribute() {
+		$html = '<img src="https://example.com/image.jpg" srcset="https://example.com/image-small.jpg 300w, https://example.com/image-large.jpg 1200w">';
+		$expected = [
+			'https://example.com/image.jpg',
+			'https://example.com/image-small.jpg',
+			'https://example.com/image-large.jpg'
+		];
+		$result = Analyze_HTML::extract_image_urls($html);
+		sort($expected);
+		sort($result);
+		$this->assertEquals($expected, $result, 'extract_image_urls should extract URLs from srcset attribute');
+	}
+
+	/**
+	 * Test with URLs in different formats (single quotes, double quotes)
+	 */
+	public function test_url_formats() {
+		$html = '
+            <img src="https://example.com/double-quotes.jpg">
+            <img src=\'https://example.com/single-quotes.jpg\'>
+        ';
+		$expected = [
+			'https://example.com/double-quotes.jpg',
+			'https://example.com/single-quotes.jpg'
+		];
+		$result = Analyze_HTML::extract_image_urls($html);
+		sort($expected);
+		sort($result);
+		$this->assertEquals($expected, $result, 'extract_image_urls should extract URLs in different quote formats');
+	}
+
+	/**
+	 * Test with URLs wrapped in parentheses
+	 */
+	public function test_urls_in_parentheses() {
+		$html = '<div style="background-image: url(https://example.com/in-parentheses.jpg)"></div>';
+		$expected = ['https://example.com/in-parentheses.jpg'];
+		$result = Analyze_HTML::extract_image_urls($html);
+		$this->assertEquals($expected, $result, 'extract_image_urls should extract URLs wrapped in parentheses');
+	}
+
+	/**
+	 * Test with URLs in CSS url() function with various formats
+	 */
+	public function test_urls_in_css_url_function() {
+		$html = '<style>
+            .bg1 { background: url(https://example.com/bg1.jpg); }
+            .bg2 { background: url("https://example.com/bg2.png"); }
+            .bg3 { background: url(\'https://example.com/bg3.gif\'); }
+            .bg4 { background: url( https://example.com/bg4.webp ); }
+        </style>';
+		$expected = [
+			'https://example.com/bg1.jpg',
+			'https://example.com/bg2.png',
+			'https://example.com/bg3.gif',
+			'https://example.com/bg4.webp'
+		];
+		$result = Analyze_HTML::extract_image_urls($html);
+		sort($expected);
+		sort($result);
+		$this->assertEquals($expected, $result, 'extract_image_urls should extract URLs from CSS url() function in various formats');
+	}
+
+	/**
+	 * Test with relative URLs
+	 */
+	public function test_relative_urls() {
+		$html = '<img src="/images/relative.jpg">';
+		$expected = [];
+		$result = Analyze_HTML::extract_image_urls($html);
+		$this->assertEquals($expected, $result, 'extract_image_urls should not extract relative URLs');
+	}
+
+	/**
+	 * Test with complex HTML structure
+	 */
+	public function test_complex_html() {
+		$html = '
+            <div class="container">
+                <figure class="wp-block-image">
+                    <a href="https://example.com">
+                        <img src="https://example.com/figure-image.jpg" alt="Figure image">
+                    </a>
+                </figure>
+                <p>Some text with <img src="https://example.com/inline-image.png"> inline image.</p>
+                <div style="background-image: url(https://example.com/background.webp)"></div>
+                <picture>
+                    <source srcset="https://example.com/image.webp" type="image/webp">
+                    <source srcset="https://example.com/image.jpg" type="image/jpeg">
+                    <img src="https://example.com/fallback.jpg">
+                </picture>
+            </div>
+        ';
+		$expected = [
+			'https://example.com/figure-image.jpg',
+			'https://example.com/inline-image.png',
+			'https://example.com/background.webp',
+			'https://example.com/image.webp',
+			'https://example.com/image.jpg',
+			'https://example.com/fallback.jpg'
+		];
+		$result = Analyze_HTML::extract_image_urls($html);
+		sort($expected);
+		sort($result);
+		$this->assertEquals($expected, $result, 'extract_image_urls did not extract all URLs from complex HTML');
+	}
+
+	/**
+	 * Test with malformed HTML
+	 */
+	public function test_malformed_html() {
+		$html = '<img src="https://example.com/image.jpg" <p>Broken HTML</p>';
+		$expected = ['https://example.com/image.jpg'];
+		$result = Analyze_HTML::extract_image_urls($html);
+		$this->assertEquals($expected, $result, 'extract_image_urls should handle malformed HTML');
+	}
+
+	/**
+	 * Test with data URLs
+	 */
+	public function test_data_urls() {
+		$html = '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==">';
+		$expected = [];
+		$result = Analyze_HTML::extract_image_urls($html);
+		$this->assertEquals($expected, $result, 'extract_image_urls should not extract data URLs');
+	}
+
+	/**
+	 * Test with URLs at the end of the string
+	 */
+	public function test_urls_at_end_of_string() {
+		$html = 'This is a URL https://example.com/image.jpg';
+		$expected = [];
+		$result = Analyze_HTML::extract_image_urls($html);
+		$this->assertEquals($expected, $result, 'extract_image_urls should not extract URLs at the end of the string');
+	}
+
+	/**
+	 * Test with URLs in inline CSS
+	 */
+	public function test_urls_in_inline_css() {
+		$html = '<div style="background: url(\'https://example.com/background.jpg\')"></div>';
+		$expected = ['https://example.com/background.jpg'];
+		$result = Analyze_HTML::extract_image_urls($html);
+		$this->assertEquals($expected, $result, 'extract_image_urls should extract URLs from inline CSS');
+	}
+
+	/**
+	 * Test with URLs in JavaScript
+	 */
+	public function test_urls_in_javascript() {
+		$html = '<script>
+            var imageUrl = "https://example.com/script-image.jpg";
+            var anotherUrl = "https://example.com/another-image.png";
+            function loadImage(url) {
+                return new Image().src = url;
+            }
+            loadImage("https://example.com/loaded-image.gif");
+        </script>';
+		$expected = [
+			'https://example.com/script-image.jpg',
+			'https://example.com/another-image.png',
+			'https://example.com/loaded-image.gif'
+		];
+		$result = Analyze_HTML::extract_image_urls($html);
+		sort($expected);
+		sort($result);
+		$this->assertEquals($expected, $result, 'extract_image_urls should extract URLs from JavaScript');
+	}
+}

--- a/tests/wpunit/includes/Image_Sources/Analyze_HTML/Extract_Images_From_Html_Test.php
+++ b/tests/wpunit/includes/Image_Sources/Analyze_HTML/Extract_Images_From_Html_Test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ISC\Tests\WPUnit\Model;
+namespace ISC\Tests\WPUnit\Includes\Image_Sources\Analyze_HTML;
 
 use ISC\Image_Sources\Analyze_HTML;
 use ISC\Tests\WPUnit\WPTestCase;

--- a/tests/wpunit/pro/Pblc/Find_More_Valid_Image_URLs_Test.php
+++ b/tests/wpunit/pro/Pblc/Find_More_Valid_Image_URLs_Test.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace ISC\Tests\WPUnit\Pro\Pblc;
+
+use ISC\Image_Sources\Analyze_HTML;
+use ISC\Image_Sources\Image_Sources;
+use ISC\Tests\WPUnit\WPTestCase;
+
+/**
+ * Test if ISC_Pro_Public:find_more_valid_image_urls() works as expected.
+ * The method finds additional image URLs as a fallback to the base function.
+ */
+class Find_More_Valid_Image_URLs_Test extends WPTestCase {
+
+	/**
+	 * Helper to extract information from HTML
+	 *
+	 * @var Analyze_HTML
+	 */
+	public $html_analyzer;
+
+	public function setUp() : void {
+		parent::setUp();
+		// Remove all hooked functions prevent accidental override.
+		remove_all_actions('isc_public_caption_regex');
+		remove_all_filters('isc_extract_images_from_html');
+
+		// Add the Pro function to the filter.
+		add_filter( 'isc_extract_images_from_html', [ 'ISC_Pro_Public', 'find_more_valid_image_urls' ], 10 );
+
+		$this->html_analyzer = new Analyze_HTML();
+	}
+
+	/**
+	 * Verify, that without the Pro function, ISC picks the value from the src attribute without checking if the URL is valid.
+	 */
+	public function test_wrong_image_url() {
+		// remove the Pro function from the filter to reproduce the default behavior.
+		remove_all_filters('isc_extract_images_from_html');
+
+		$html     = '<img src="data:base" data="https://example.com/image.png">';
+		$expected = [
+			[
+				'full'         => '<img src="data:base" data="https://example.com/image.png">',
+				'figure_class' => '',
+				'inner_code'   => '<img src="data:base" data="https://example.com/image.png">',
+				'img_src'      => 'data:base',
+			],
+		];
+
+		$result = $this->html_analyzer->extract_images_from_html( $html );
+		$this->assertEquals( $expected, $result, 'without find_more_valid_image_urls(), the invalid value from src is picked' );
+	}
+
+	/**
+	 * Test if the function returns the valid image URL from the data attribute.
+	 */
+	public function test_datasrc_attribute() {
+		$html     = '<img src="data:base" data="https://example.com/image.png">';
+		$expected = [
+			[
+				'full'         => '<img src="data:base" data="https://example.com/image.png">',
+				'figure_class' => '',
+				'inner_code'   => '<img src="data:base" data="https://example.com/image.png">',
+				'img_src'      => 'https://example.com/image.png',
+			],
+		];
+
+		$result = $this->html_analyzer->extract_images_from_html( $html );
+		$this->assertEquals( $expected, $result, 'find_more_valid_image_urls should extract the valid image URL' );
+	}
+
+	/**
+	 * Test if the function returns the first valid image URL.
+	 */
+	public function test_multiple_urls() {
+		$html     = '<img src="data:base" data="https://example.com/first.png" data-src="https://example.com/second.png">';
+		$expected = [
+			[
+				'full'         => '<img src="data:base" data="https://example.com/first.png" data-src="https://example.com/second.png">',
+				'figure_class' => '',
+				'inner_code'   => '<img src="data:base" data="https://example.com/first.png" data-src="https://example.com/second.png">',
+				'img_src'      => 'https://example.com/first.png',
+			],
+		];
+
+		$result = $this->html_analyzer->extract_images_from_html( $html );
+		$this->assertEquals( $expected, $result, 'find_more_valid_image_urls should extract the valid image URL' );
+	}
+}

--- a/tests/wpunit/pro/includes/compatibility/Kadence_Test.php
+++ b/tests/wpunit/pro/includes/compatibility/Kadence_Test.php
@@ -2,7 +2,8 @@
 
 namespace ISC\Tests\WPUnit\Pro\Includes\Compatibility;
 
-use ISC\Tests\WPUnit\Model\Extract_Images_From_Html_Test;
+use ISC\Tests\WPUnit\Includes\Image_Sources\Analyze_HTML\Extract_Images_From_Html_Test;
+
 /**
  * Test if ISC_Pro_Kadence provides compatibility with Kadence Blocks and Kadence Theme specific HTML.
  * This test is based on the Extract_Images_From_Html_Test class to see if all previous patters also work


### PR DESCRIPTION
Tests for the new extract method, which also lead to minor improvements in them:

- reset array keys when removing duplicate URLs
- find URLs wrapped in brackets