### PR TITLE
Fix trait warnings for PHP 8.1

### DIFF
--- a/admin/includes/scripts.php
+++ b/admin/includes/scripts.php
@@ -2,12 +2,13 @@
 
 namespace ISC\Admin;
 
-use ISC\Admin_Utils;
+use \ISC\Admin_Utils;
 
 /**
  * Add general admin scripts
  */
 class Admin_Scripts {
+
 	/**
 	 * Constructor
 	 */

--- a/admin/utils.php
+++ b/admin/utils.php
@@ -5,7 +5,7 @@ namespace ISC;
 /**
  * Admin Utils
  */
-trait Admin_Utils {
+class Admin_Utils {
 	/**
 	 * Get the ISC pages
 	 *

--- a/includes/image-sources/admin.php
+++ b/includes/image-sources/admin.php
@@ -2,11 +2,12 @@
 
 namespace ISC\Image_Sources;
 
+use \ISC\Admin_Utils;
+
 /**
  * Admin features for image sources
  */
 class Admin {
-	use \ISC\Admin_Utils;
 	use \ISC\Options;
 	use Utils;
 

--- a/includes/image-sources/admin/fields.php
+++ b/includes/image-sources/admin/fields.php
@@ -3,13 +3,13 @@
 namespace ISC\Image_Sources;
 
 use ISC\Plugin;
+use \ISC\Admin_Utils;
 
 /**
  * Add fields for the image sources to the backend
  */
 class Admin_Fields {
 	use \ISC\Options;
-	use \ISC\Admin_Utils;
 
 	/**
 	 * Constructor
@@ -56,7 +56,7 @@ class Admin_Fields {
 		if ( ! Plugin::is_pro() ) {
 			$form_fields['isc_image_source_pro']['label'] = '';
 			$form_fields['isc_image_source_pro']['input'] = 'html';
-			$form_fields['isc_image_source_pro']['html']  = self::get_pro_link( 'attachment-edit' );
+			$form_fields['isc_image_source_pro']['html']  = Admin_Utils::get_pro_link( 'attachment-edit' );
 		}
 
 		// add input field for source
@@ -110,7 +110,7 @@ class Admin_Fields {
 		$form_fields['isc_image_usage']['label'] = __( 'Appearances', 'image-source-control-isc' );
 		$form_fields['isc_image_usage']['html']  = __( 'Where is this file used?', 'image-source-control-isc' );
 		// add pro link
-		$form_fields['isc_image_usage']['html'] .= ' ' . self::get_pro_link( 'media-library-usage' );
+		$form_fields['isc_image_usage']['html'] .= ' ' . Admin_Utils::get_pro_link( 'media-library-usage' );
 
 		return apply_filters( 'isc_admin_attachment_form_fields', $form_fields, $post, $options );
 	}

--- a/includes/image-sources/admin/media-library-filters.php
+++ b/includes/image-sources/admin/media-library-filters.php
@@ -2,7 +2,7 @@
 
 namespace ISC\Image_Sources;
 
-use ISC\Admin_Utils;
+use \ISC\Admin_Utils;
 
 /**
  * Handle filters in the Media Library
@@ -136,7 +136,7 @@ class Admin_Media_Library_Filters {
 			// add pro link
 			if ( ! \ISC\Plugin::is_pro() ) {
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				echo '<p>' . \ISC\Admin_Utils::get_pro_link( 'media-library-missing-image-sources-column-notice' ) . '</p>';
+				echo '<p>' . Admin_Utils::get_pro_link( 'media-library-missing-image-sources-column-notice' ) . '</p>';
 			}
 			echo '</div>';
 		}

--- a/includes/isc.class.php
+++ b/includes/isc.class.php
@@ -111,7 +111,7 @@ class ISC_Class {
 		public function default_options() {
 			_deprecated_function( __METHOD__, '3.0.0', 'ISC\Options::default_options' );
 
-			return ISC\Options::default_options();
+			return ISC\Plugin::default_options();
 		}
 
 		/**

--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -6,6 +6,8 @@ namespace ISC;
  * Plugin class
  */
 class Plugin {
+	use Options;
+
 	/**
 	 * Check if this is the pro version
 	 *
@@ -16,15 +18,6 @@ class Plugin {
 	}
 
 	/**
-	 * Returns isc_options if it exists, returns the default options otherwise.
-	 *
-	 * @return array
-	 */
-	public static function get_options() {
-		return Options::get_options();
-	}
-
-	/**
 	 * Return true if the mentioned module is enabled
 	 *
 	 * @param string $module module name.
@@ -32,7 +25,7 @@ class Plugin {
 	 * @return bool
 	 */
 	public static function is_module_enabled( string $module ) {
-		$options = Options::get_options();
+		$options = self::get_options();
 
 		// all modules are enabled by default; i.e., when the option is not set
 		if ( ! isset( $options['modules'] ) ) {

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -99,7 +99,7 @@ class Settings {
 	 * Manage data structure upgrading of outdated versions
 	 */
 	public function upgrade_settings() {
-		$default_options = Options::default_options();
+		$default_options = Plugin::default_options();
 
 		/**
 		 * This function checks options in database

--- a/includes/settings/sections/licenses.php
+++ b/includes/settings/sections/licenses.php
@@ -35,7 +35,7 @@ class Licenses extends Settings\Section {
 		// fall back to default if field is empty
 		if ( empty( $options['licences'] ) ) {
 			// retrieve default options
-			$default = \ISC\Options::default_options();
+			$default = \ISC\Plugin::default_options();
 			if ( ! empty( $default['licences'] ) ) {
 				$options['licences'] = $default['licences'];
 			}


### PR DESCRIPTION
The Traits I was using threw an error in PHP 8.1, which I resolved by correctly using `ISC\Options` and changing `ISC\Admin_Utils` to a normal class since that was its main usage anyway.