### PR TITLE
Fix Images with sources filter

### DIFF
--- a/includes/image-sources/admin/media-library-filters.php
+++ b/includes/image-sources/admin/media-library-filters.php
@@ -55,8 +55,8 @@ class Admin_Media_Library_Filters {
 				[
 					'relation' => 'OR',
 					[
-						'key'     => 'isc_image_source_own',
-						'compare' => 'EXISTS',
+						'key'   => 'isc_image_source_own',
+						'value' => '1',
 					],
 					[
 						'relation' => 'AND',

--- a/readme.txt
+++ b/readme.txt
@@ -153,6 +153,10 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 
 == Changelog ==
 
+= untagged =
+
+- Fix: The filter “Images with sources” in the Media Library list view was not working correctly
+
 = 3.1.2 =
 
 - Fix: Indexer not loading due to changed screen ID


### PR DESCRIPTION
The filter “Images with sources” in the Media Library list view was not working correctly due to an incorrect query.