### PR TITLE
Fixed PHP 8.2 error when saving settings

### DIFF
--- a/includes/settings/sections/global-list.php
+++ b/includes/settings/sections/global-list.php
@@ -161,7 +161,7 @@ class Global_List extends Settings\Section {
 
 		if ( ! empty( $input['thumbnail_in_list'] ) ) {
 			$output['thumbnail_in_list'] = true;
-			if ( in_array( $input['thumbnail_size'], $this->thumbnail_size, true ) ) {
+			if ( in_array( $input['thumbnail_size'], Image_Sources::get_thumbnail_sizes(), true ) ) {
 				$output['thumbnail_size'] = $input['thumbnail_size'];
 			}
 			if ( 'custom' === $input['thumbnail_size'] ) {

--- a/readme.txt
+++ b/readme.txt
@@ -160,6 +160,7 @@ See the _Instructions_ section [here](https://wordpress.org/plugins/image-source
 = 3.1.2 =
 
 - Fix: Indexer not loading due to changed screen ID
+- Fix: PHP warning when saving the Global List settings in PHP 8.2
 
 = 3.1.1 =
 


### PR DESCRIPTION
A missing class parameter caused the Global List thumbnail settings to be saved and threw a PHP error in PHP 8.2.