### PR TITLE
Images-only option

### DIFF
--- a/admin/assets/js/settings.js
+++ b/admin/assets/js/settings.js
@@ -17,7 +17,10 @@ jQuery( document ).ready(
 		$( '#thumbnail-size-select, #use-thumbnail' ).on( 'change', function(){ isc_thumbnail_input_checkstate(); } );
 		$( '#isc-settings-caption-style input' ).on( 'change', function(){ isc_toggle_caption_position(); } );
 		$( '#isc-settings-global-list-indexed-images' ).on( 'change', function(){ isc_show_reindex_warning(); } );
-		$('#isc-settings-plugin-modules input[type="checkbox"]').on('change', function() { isc_toggle_module_sections(); });
+		$( '#isc-settings-plugin-modules input[type="checkbox"]').on('change', function() { isc_toggle_module_sections(); });
+		$( '#isc-settings-plugin-images-only' ).on( 'change', function() {
+			$( '#isc-settings-plugin-images-only-indexer' ).toggleClass( 'hidden' );
+		});
 
 		// Show and update preview when a position option is clicked
 		$('#isc-settings-caption-pos-options button').on( 'click', function (event) {

--- a/admin/templates/settings/plugin/images-only.php
+++ b/admin/templates/settings/plugin/images-only.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Template for the images only option
+ *
+ * @var bool $checked Whether the option is checked
+ */
+
+?>
+<label>
+	<input id="isc-settings-plugin-images-only" type="checkbox" name="isc_options[images_only]" value="1" <?php checked( $checked ); ?> />
+</label>
+<p class="description">
+	<?php esc_html_e( 'When enabled, all plugin functions will only work with image files and ignore other media types.', 'image-source-control-isc' ); ?>
+</p>
+<p class="hidden" id="isc-settings-plugin-images-only-indexer">
+	<i class="dashicons dashicons-info"></i>
+	<?php
+	if ( \ISC\Plugin::is_pro() ) :
+		$open_a  = '<a href="' . admin_url( 'options.php?page=isc-indexer' ) . '">';
+		$close_a = '</a>';
+	else :
+		// don’t link to the indexer page since it is not
+		$open_a  = '';
+		$close_a = '';
+	endif;
+	printf(
+	// translators: %%1$s is an opening link tag, %2$s is the closing one
+		esc_html__( 'Run the %1$sIndexer%2$s to update all data at once.', 'image-source-control-isc' ),
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		$open_a,
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		$close_a
+	);
+	?>
+	<?php
+	if ( ! \ISC\Plugin::is_pro() ) :
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo \ISC\Admin_Utils::get_pro_link( 'settings-images-only-indexer' );
+	endif;
+	?>
+</p>

--- a/includes/image-sources/admin/fields.php
+++ b/includes/image-sources/admin/fields.php
@@ -28,6 +28,11 @@ class Admin_Fields {
 	 * @return array with form fields
 	 */
 	public function add_isc_fields( $form_fields, $post ) {
+		// Check if we should process this attachment based on settings
+		if ( ! \ISC\Media_Type_Checker::should_process_attachment( $post->ID ) ) {
+			return $form_fields;
+		}
+
 		/**
 		 * Return, when the ISC fields are enabled for blocks, and we are not using the block editor.
 		 * It is tricky to detect and easy to break, so here is more information on it:

--- a/includes/image-sources/admin/media-library-filters.php
+++ b/includes/image-sources/admin/media-library-filters.php
@@ -49,6 +49,11 @@ class Admin_Media_Library_Filters {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$filter = isset( $_GET['isc_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['isc_filter'] ) ) : '';
 
+		// Add image type check if images_only is enabled
+		if ( \ISC\Media_Type_Checker::enabled_images_only_option() ) {
+			$query->set( 'post_mime_type', 'image%' );
+		}
+
 		if ( $filter === 'with_source' ) {
 			$query->set(
 				'meta_query',

--- a/includes/media-type-checker.php
+++ b/includes/media-type-checker.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace ISC;
+
+/**
+ * Class to check media types
+ */
+class Media_Type_Checker {
+
+	/**
+	 * Check if an attachment is an image
+	 *
+	 * @param int $attachment_id The attachment ID to check.
+	 *
+	 * @return bool True if the attachment is an image, false otherwise.
+	 */
+	public static function is_image( int $attachment_id ): bool {
+		$mime_type = get_post_mime_type( $attachment_id );
+		if ( ! $mime_type ) {
+			return false;
+		}
+
+		return strpos( $mime_type, 'image/' ) === 0;
+	}
+
+	/**
+	 * Check the images-only option
+	 *
+	 * @return bool True if images-only is enabled, false otherwise.
+	 */
+	public static function enabled_images_only_option(): bool {
+		$options = \ISC\Plugin::get_options();
+
+		// Check if images_only is enabled
+		return ! empty( $options['images_only'] );
+	}
+
+	/**
+	 * Check if we should process this attachment based on settings
+	 *
+	 * @param int $attachment_id The attachment ID to check.
+	 *
+	 * @return bool True if we should process this attachment, false otherwise.
+	 */
+	public static function should_process_attachment( int $attachment_id ): bool {
+		// If images_only is enabled, only process images
+		if ( self::enabled_images_only_option() ) {
+			return self::is_image( $attachment_id );
+		}
+
+		// Otherwise process all attachments
+		return true;
+	}
+}

--- a/includes/options.php
+++ b/includes/options.php
@@ -83,6 +83,7 @@ GFDL GNU Free Documentation License 1.3|https://www.gnu.org/licenses/fdl-1.3.htm
 		$default['enable_log']                = false;
 		$default['standard_source']           = 'custom_text';
 		$default['standard_source_text']      = '';
+		$default['images_only']               = false;
 
 		/**
 		 * Allow manipulating defaults for plugin settings

--- a/includes/settings/sections/plugin-options.php
+++ b/includes/settings/sections/plugin-options.php
@@ -16,6 +16,7 @@ class Plugin_Options extends Settings\Section {
 		// Misc settings group
 		add_settings_section( 'isc_settings_section_plugin', __( 'Plugin options', 'image-source-control-isc' ), '__return_false', 'isc_settings_page' );
 		add_settings_field( 'modules', __( 'Modules', 'image-source-control-isc' ), [ $this, 'render_field_modules' ], 'isc_settings_page', 'isc_settings_section_plugin' );
+		add_settings_field( 'images_only', __( 'Images only', 'image-source-control-isc' ), [ $this, 'render_field_images_only' ], 'isc_settings_page', 'isc_settings_section_plugin' );
 		add_settings_field( 'remove_on_uninstall', __( 'Delete data on uninstall', 'image-source-control-isc' ), [ $this, 'render_field_remove_on_uninstall' ], 'isc_settings_page', 'isc_settings_section_plugin' );
 	}
 
@@ -36,6 +37,15 @@ class Plugin_Options extends Settings\Section {
 	}
 
 	/**
+	 * Render the option to restrict functionality to images only.
+	 */
+	public function render_field_images_only() {
+		$options = $this->get_options();
+		$checked = ! empty( $options['images_only'] );
+		require_once ISCPATH . '/admin/templates/settings/plugin/images-only.php';
+	}
+
+	/**
 	 * Render the option to remove all options and meta data when the plugin is deleted.
 	 */
 	public function render_field_remove_on_uninstall() {
@@ -53,8 +63,8 @@ class Plugin_Options extends Settings\Section {
 	 * @return array $output
 	 */
 	public function validate_settings( array $output, array $input ): array {
-
 		$output['modules']             = ( isset( $input['modules'] ) && is_array( $input['modules'] ) ) ? $input['modules'] : [];
+		$output['images_only']         = ! empty( $input['images_only'] );
 		$output['remove_on_uninstall'] = ! empty( $input['remove_on_uninstall'] );
 
 		return $output;

--- a/lib/composer/autoload_classmap.php
+++ b/lib/composer/autoload_classmap.php
@@ -28,6 +28,7 @@ return array(
     'ISC\\Image_Sources\\Renderer\\Image_Source_String' => $baseDir . '/includes/image-sources/renderer/image-source-string.php',
     'ISC\\Image_Sources\\Utils' => $baseDir . '/includes/image-sources/utils.php',
     'ISC\\Indexer' => $baseDir . '/includes/indexer.php',
+    'ISC\\Media_Type_Checker' => $baseDir . '/includes/media-type-checker.php',
     'ISC\\Newsletter' => $baseDir . '/includes/newsletter.php',
     'ISC\\Options' => $baseDir . '/includes/options.php',
     'ISC\\Plugin' => $baseDir . '/includes/plugin.php',

--- a/lib/composer/autoload_static.php
+++ b/lib/composer/autoload_static.php
@@ -48,6 +48,7 @@ class ComposerStaticInitdb72a6bac11cb0e6b971811c93d09a9b
         'ISC\\Image_Sources\\Renderer\\Image_Source_String' => __DIR__ . '/../..' . '/includes/image-sources/renderer/image-source-string.php',
         'ISC\\Image_Sources\\Utils' => __DIR__ . '/../..' . '/includes/image-sources/utils.php',
         'ISC\\Indexer' => __DIR__ . '/../..' . '/includes/indexer.php',
+        'ISC\\Media_Type_Checker' => __DIR__ . '/../..' . '/includes/media-type-checker.php',
         'ISC\\Newsletter' => __DIR__ . '/../..' . '/includes/newsletter.php',
         'ISC\\Options' => __DIR__ . '/../..' . '/includes/options.php',
         'ISC\\Plugin' => __DIR__ . '/../..' . '/includes/plugin.php',

--- a/public/public.php
+++ b/public/public.php
@@ -628,6 +628,12 @@ class ISC_Public extends \ISC\Image_Sources\Image_Sources {
 		$connected_atts = [];
 
 		foreach ( $attachments as $_attachment ) {
+			// skip non-images if option is selected
+			if ( ! \ISC\Media_Type_Checker::should_process_attachment( $_attachment->ID ) ) {
+				ISC_Log::log( sprintf( 'skipped image %d because it is not an image', $_attachment->ID ) );
+				continue;
+			}
+
 			$connected_atts[ $_attachment->ID ]['source']   = self::get_image_source_text_raw( $_attachment->ID );
 			$connected_atts[ $_attachment->ID ]['standard'] = Standard_Source::use_standard_source( $_attachment->ID );
 			// jump to next element if the standard source is set to be excluded from the source list

--- a/tests/wpunit/includes/Media_Type_Checker_Test.php
+++ b/tests/wpunit/includes/Media_Type_Checker_Test.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace ISC\Tests\WPUnit\Includes;
+
+use ISC\Tests\WPUnit\WPTestCase;
+use ISC\Media_Type_Checker;
+
+/**
+ * Test if ISC\Media_Type_Checker works as expected.
+ */
+class Media_Type_Checker_Test extends WPTestCase {
+
+	/**
+	 * @var int
+	 */
+	private $image_id;
+
+	/**
+	 * @var int
+	 */
+	private $document_id;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// Create an image attachment
+		$this->image_id = self::factory()->attachment->create( [
+			'post_mime_type' => 'image/jpeg',
+			'post_type' => 'attachment',
+		] );
+
+		// Create a document attachment
+		$this->document_id = self::factory()->attachment->create( [
+			'post_mime_type' => 'application/pdf',
+			'post_type' => 'attachment',
+		] );
+	}
+
+	/**
+	 * Test if should_process_attachment returns true for images when images_only is enabled
+	 */
+	public function test_should_process_attachment_image_with_images_only() {
+		// Enable images_only option
+		$options = \ISC\Plugin::get_options();
+		$options['images_only'] = true;
+		update_option( 'isc_options', $options );
+
+		$result = Media_Type_Checker::should_process_attachment( $this->image_id );
+		$this->assertTrue( $result, 'should_process_attachment should return true for images when images_only is enabled' );
+	}
+
+	/**
+	 * Test if should_process_attachment returns false for non-images when images_only is enabled
+	 */
+	public function test_should_process_attachment_non_image_with_images_only() {
+		// Enable images_only option
+		$options = \ISC\Plugin::get_options();
+		$options['images_only'] = true;
+		update_option( 'isc_options', $options );
+
+		$result = Media_Type_Checker::should_process_attachment( $this->document_id );
+		$this->assertFalse( $result, 'should_process_attachment should return false for non-images when images_only is enabled' );
+	}
+
+	/**
+	 * Test if should_process_attachment returns true for all attachments when images_only is disabled
+	 */
+	public function test_should_process_attachment_without_images_only() {
+		// Disable images_only option
+		$options = \ISC\Plugin::get_options();
+		$options['images_only'] = false;
+		update_option( 'isc_options', $options );
+
+		$result_image = Media_Type_Checker::should_process_attachment( $this->image_id );
+		$result_doc = Media_Type_Checker::should_process_attachment( $this->document_id );
+
+		$this->assertTrue( $result_image, 'should_process_attachment should return true for images when images_only is disabled' );
+		$this->assertTrue( $result_doc, 'should_process_attachment should return true for non-images when images_only is disabled' );
+	}
+
+	/**
+	 * Test if should_process_attachment returns true for invalid attachment IDs
+	 * if the option to process only images isn’t enabled
+	 */
+	public function test_should_process_attachment_invalid_id_without_images_only() {
+		$result = Media_Type_Checker::should_process_attachment( 999999 );
+		$this->assertTrue( $result, 'should_process_attachment should return true for invalid attachment IDs if Images-only isn’t enabled' );
+	}
+
+	/**
+	 * Test if should_process_attachment returns false for invalid attachment IDs
+	 * if the option to process only images is enabled
+	 */
+	public function test_should_process_attachment_invalid_id_with_images_only() {
+		// Disable images_only option
+		$options = \ISC\Plugin::get_options();
+		$options['images_only'] = true;
+		update_option( 'isc_options', $options );
+
+		$result = Media_Type_Checker::should_process_attachment( 999999 );
+		$this->assertFalse( $result, 'should_process_attachment should return false for invalid attachment IDs if Images-only is enabled' );
+	}
+
+	/**
+	 * Test if should_process_attachment returns true for non-attachment post types
+	 * if the option to process only images isn’t enabled
+	 */
+	public function test_should_process_attachment_non_attachment_without_images_only() {
+		$post_id = self::factory()->post->create();
+		$result = Media_Type_Checker::should_process_attachment( $post_id );
+
+		$this->assertTrue( $result, 'should_process_attachment should return true for non-attachment post types if Images-only isn’t enabled' );
+	}
+} 

--- a/tests/wpunit/pro/admin/includes/Unused_Images_Get_Unused_Attachments_Test.php
+++ b/tests/wpunit/pro/admin/includes/Unused_Images_Get_Unused_Attachments_Test.php
@@ -11,6 +11,33 @@ use ISC\Tests\WPUnit\Includes\Unused_Images_Basic_Test;
 class Unused_Images_Get_Unused_Attachments_Test extends Unused_Images_Basic_Test {
 
 	/**
+	 * Set the images_only setting.
+	 *
+	 * @param bool $enabled
+	 */
+	private function setImagesOnly( bool $enabled ): void {
+		$options = \ISC\Plugin::get_options();
+		$options['images_only'] = $enabled;
+		update_option( 'isc_options', $options );
+	}
+
+	/**
+	 * Create an attachment with a specific mime type.
+	 *
+	 * @param string $mime
+	 * @return int
+	 */
+	private function createAttachmentWithMime( string $mime ): int {
+		$att_id = $this->factory->attachment->create( [
+			                                              'post_mime_type' => $mime,
+			                                              'post_type'      => 'attachment',
+		                                              ] );
+
+		$this->attachment_ids[] = $att_id;
+		return $att_id;
+	}
+
+	/**
 	 * Test with the filter set to "unchecked"
 	 */
 	public function test_filter_unchecked() {
@@ -51,5 +78,61 @@ class Unused_Images_Get_Unused_Attachments_Test extends Unused_Images_Basic_Test
 
 		// only one attachment should match
 		$this->assertCount( 1, $unused_attachments );
+	}
+
+	/**
+	 * Test: when images_only is disabled, non-image attachments are included.
+	 */
+	public function test_images_only_disabled_includes_all_mime_types() {
+		$this->setImagesOnly( false );
+
+		// Create one image and one non-image attachment
+		$image_id = $this->createAttachmentWithMime( 'image/png' );
+		$doc_id   = $this->createAttachmentWithMime( 'application/pdf' );
+
+		$results = Unused_Images::get_unused_attachments();
+		$ids     = wp_list_pluck( $results, 'ID' );
+
+		$this->assertContains( $image_id, $ids, 'Expected image to be in unused attachments' );
+		$this->assertContains( $doc_id, $ids, 'Expected document to be in unused attachments' );
+	}
+
+	/**
+	 * Test: when images_only is enabled, non-image attachments are excluded.
+	 */
+	public function test_images_only_enabled_excludes_non_images() {
+		$this->setImagesOnly( true );
+
+		// Create one image and one non-image attachment
+		$image_id = $this->createAttachmentWithMime( 'image/jpeg' );
+		$doc_id   = $this->createAttachmentWithMime( 'application/pdf' );
+
+		$results = Unused_Images::get_unused_attachments();
+		$ids     = wp_list_pluck( $results, 'ID' );
+
+		$this->assertContains( $image_id, $ids, 'Expected image to be in unused attachments' );
+		$this->assertNotContains( $doc_id, $ids, 'Expected non-image to be excluded when images_only is enabled' );
+	}
+
+	/**
+	 * Test: images_only enabled + filter "unchecked".
+	 */
+	public function test_images_only_enabled_with_filter_unchecked() {
+		$this->setImagesOnly( true );
+
+		// Create one image and one non-image
+		$image_id = $this->createAttachmentWithMime( 'image/webp' );
+		$doc_id   = $this->createAttachmentWithMime( 'application/pdf' );
+
+		// Mark both as already checked
+		add_post_meta( $doc_id, 'isc_possible_usages', '' );
+		add_post_meta( $image_id, 'isc_possible_usages', '' );
+
+		// Should return nothing because both are considered checked
+		$results = Unused_Images::get_unused_attachments( [ 'filter' => 'unchecked' ] );
+		$this->assertEmpty( $results, 'No attachments should match unchecked if all were checked' );
+
+		delete_post_meta( $doc_id, 'isc_possible_usages' );
+		delete_post_meta( $image_id, 'isc_possible_usages' );
 	}
 }


### PR DESCRIPTION
Added an option to ignore non-images files

This commit only adds that option and disables the ISC fields in the media library overlay appropriately. Further checks are coming next.