### PR TITLE
Tests extract method

### DIFF
--- a/admin/assets/js/sources.js
+++ b/admin/assets/js/sources.js
@@ -101,6 +101,35 @@ jQuery( document ).ready(
 				);
 			}
 		);
+		// show frontend storage
+		$( '#isc-show-storage' ).on(
+			'click',
+			function(){
+				// disable the button
+				var button      = this;
+				button.disabled = true;
+
+				$.ajax(
+					{
+						type: 'POST',
+						url: ajaxurl,
+						data: {
+							action: 'isc-show-storage',
+							nonce: isc.ajaxNonce,
+						},
+						success:function(data, textStatus, XMLHttpRequest){
+							// display return messages
+							$( '#isc-show-storage-output' ).html( data );
+							button.disabled = false;
+						},
+						error: function(MLHttpRequest, textStatus, errorThrown){
+							$( '#isc-show-storage-output' ).html( errorThrown );
+							button.disabled = false;
+						}
+					}
+				);
+			}
+		);
 		// clear frontend storage
 		$( '#isc-clear-storage' ).on(
 			'click',

--- a/admin/templates/sources/storage.php
+++ b/admin/templates/sources/storage.php
@@ -21,3 +21,12 @@ printf(
 	</p>
 <button id="isc-clear-storage" class="button button-secondary"><?php esc_html_e( 'clear storage', 'image-source-control-isc' ); ?></button>
 <div id="isc-clear-storage-feedback"></div>
+<?php
+// if the WordPress debug mode is enabled, show the button to dump the storage
+if ( $storage_size > 0 && defined( 'WP_DEBUG' ) && WP_DEBUG ) :
+	?>
+	<br/>
+	<button id="isc-show-storage" class="button button-secondary"><?php esc_html_e( 'show storage', 'image-source-control-isc' ); ?></button>
+	<pre id="isc-show-storage-output"></pre>
+	<?php
+endif; ?>

--- a/includes/image-sources/admin/ajax.php
+++ b/includes/image-sources/admin/ajax.php
@@ -17,6 +17,7 @@ class Admin_Ajax {
 		add_action( 'wp_ajax_isc-post-image-relations', [ $this, 'list_post_image_relations' ] );
 		add_action( 'wp_ajax_isc-image-post-relations', [ $this, 'list_image_post_relations' ] );
 		add_action( 'wp_ajax_isc-clear-index', [ $this, 'clear_index' ] );
+		add_action( 'wp_ajax_isc-show-storage', [ $this, 'show_storage' ] );
 		add_action( 'wp_ajax_isc-clear-storage', [ $this, 'clear_storage' ] );
 		add_action( 'wp_ajax_isc-clear-image-posts-index', [ $this, 'clear_image_posts_index' ] );
 		add_action( 'wp_ajax_isc-clear-post-images-index', [ $this, 'clear_post_images_index' ] );
@@ -104,6 +105,26 @@ class Admin_Ajax {
 				(int) ISC_Model::clear_index()
 			)
 		);
+	}
+
+	/**
+	 * Show the storage array for debugging
+	 */
+	public function show_storage() {
+		check_ajax_referer( 'isc-admin-ajax-nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			die( 'Wrong capabilities' );
+		}
+
+		$storage_model = new \ISC_Storage_Model();
+		$images        = $storage_model->get_storage();
+
+		// We are in debug mode, so it is fine to just output the content
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+		print_r( $images );
+
+		die();
 	}
 
 	/**

--- a/includes/image-sources/analyze-html.php
+++ b/includes/image-sources/analyze-html.php
@@ -119,7 +119,15 @@ class Analyze_HTML {
 
 	/**
 	 * Extract image URLs from HTML.
-	 * One image URL per HTML tag will be found.
+	 * One image URL per HTML attribute will be found.
+	 *
+	 * Limitations:
+	 * - retrieves the first valid image URL from any HTML tag
+	 * - if an IMG tag has a SRC attribute with a valid image URL, all other tags with valid URLs are ignored
+	 * - technically, one could generate tags with different images from the Media Library, e.g., having a differently cut URL in a data-attribute
+	 *  that then shows dynamically using JavaScript
+	 *  this would cause one of the images not being listed with a source or a used image
+	 *  since I haven’t seen that in the wild, this case is deliberately ignored
 	 *
 	 * @param string $html Any HTML code.
 	 * @return array List of image URLs.


### PR DESCRIPTION
Extend tests for methods that retrieve image URLs from HTML to cover more edge cases.
Added debug output for the storage array on the Tools page.