### PR TITLE
Replace DB calls with WP functions

### DIFF
--- a/includes/image-sources/Post_Meta/Image_Posts_Meta.php
+++ b/includes/image-sources/Post_Meta/Image_Posts_Meta.php
@@ -69,13 +69,10 @@ class Image_Posts_Meta {
 	 * Remove post_images index
 	 * namely the post meta field `isc_image_posts`
 	 *
-	 * @return int|false The number of rows updated, or false on error.
+	 * @return bool True on success, false on failure.
 	 */
-	public static function delete_all() {
-		global $wpdb;
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-		return $wpdb->delete( $wpdb->postmeta, [ 'meta_key' => self::META_KEY ], [ '%s' ] );
+	public static function delete_all(): bool {
+		return delete_post_meta_by_key( self::META_KEY );
 	}
 
 	/**

--- a/includes/image-sources/Post_Meta/Post_Images_Meta.php
+++ b/includes/image-sources/Post_Meta/Post_Images_Meta.php
@@ -69,13 +69,10 @@ class Post_Images_Meta {
 	 * Remove post_images index
 	 * namely the post meta field `isc_post_images`
 	 *
-	 * @return int|false The number of rows updated, or false on error.
+	 * @return bool True on success, false on failure.
 	 */
-	public static function delete_all() {
-		global $wpdb;
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-		return $wpdb->delete( $wpdb->postmeta, [ 'meta_key' => self::META_KEY ], [ '%s' ] );
+	public static function delete_all(): bool {
+		return delete_post_meta_by_key( self::META_KEY );
 	}
 
 	/**

--- a/includes/image-sources/admin/ajax.php
+++ b/includes/image-sources/admin/ajax.php
@@ -4,7 +4,6 @@ namespace ISC\Image_Sources;
 
 use ISC\Image_Sources\Post_Meta\Image_Posts_Meta;
 use ISC\Image_Sources\Post_Meta\Post_Images_Meta;
-use ISC_Model;
 
 /**
  * Handle AJAX calls
@@ -100,13 +99,11 @@ class Admin_Ajax {
 			die( 'Wrong capabilities' );
 		}
 
-		die(
-			sprintf(
-			// translators: %d is the number of deleted entries
-				esc_html__( '%d entries deleted', 'image-source-control-isc' ),
-				(int) ISC_Model::clear_index()
-			)
-		);
+		if ( \ISC\Indexer::clear_index() ) {
+			wp_send_json_success( esc_html__( 'Index cleared', 'image-source-control-isc' ) );
+		} else {
+			wp_send_json_error( 'Error' );
+		}
 	}
 
 	/**

--- a/includes/indexer.php
+++ b/includes/indexer.php
@@ -348,17 +348,10 @@ class Indexer {
 	 * Remove all image-post relations
 	 * this concerns the post meta fields `isc_image_posts` and `isc_post_images`
 	 *
-	 * @return int|false The number of rows updated, or false on error.
+	 * @return bool True on success, false on failure.
 	 */
-	public static function clear_index() {
-		$rows_deleted_1 = Post_Images_Meta::delete_all();
-		$rows_deleted_2 = Image_Posts_Meta::delete_all();
-
-		if ( $rows_deleted_1 !== false && $rows_deleted_2 !== false ) {
-			return $rows_deleted_1 + $rows_deleted_2;
-		}
-
-		return false;
+	public static function clear_index(): bool {
+		return Post_Images_Meta::delete_all() && Image_Posts_Meta::delete_all();
 	}
 
 	/**

--- a/includes/model.php
+++ b/includes/model.php
@@ -179,12 +179,12 @@ class ISC_Model {
 	 * Remove all image-post relations
 	 * this concerns the post meta fields `isc_image_posts` and `isc_post_images`
 	 *
-	 * @moved since April 2025
+	 * @deprecated since April 2025
 	 *
-	 * @return int|false The number of rows updated, or false on error.
+	 * @return bool True if the option was removed
 	 */
-	public static function clear_index() {
-		ISC_Log::log( 'function moved. \ISC\Image_Sources\Post_Meta::clear_index' );
+	public static function clear_index(): bool {
+		ISC_Log::log( 'function moved. \ISC\Indexer::clear_index' );
 
 		return Indexer::clear_index();
 	}

--- a/tests/wpunit/includes/Image_Sources/Post_Meta/Image_Posts_Meta_Test.php
+++ b/tests/wpunit/includes/Image_Sources/Post_Meta/Image_Posts_Meta_Test.php
@@ -54,10 +54,7 @@ class Image_Posts_Meta_Test extends WPTestCase {
 
 		$deleted = Image_Posts_Meta::delete_all();
 
-		wp_cache_delete( $image_id_1, 'post_meta' );
-		wp_cache_delete( $image_id_2, 'post_meta' );
-
-		$this->assertGreaterThanOrEqual( 2, $deleted );
+		$this->assertTrue( $deleted );
 		$this->assertEmpty( Image_Posts_Meta::get( $image_id_1 ) );
 		$this->assertEmpty( Image_Posts_Meta::get( $image_id_2 ) );
 	}

--- a/tests/wpunit/includes/Image_Sources/Post_Meta/Post_Images_Meta_Test.php
+++ b/tests/wpunit/includes/Image_Sources/Post_Meta/Post_Images_Meta_Test.php
@@ -265,13 +265,9 @@ class Post_Images_Meta_Test extends WPTestCase {
 		$this->assertNotEmpty( Post_Images_Meta::get( $post_id_1 ) );
 		$this->assertNotEmpty( Post_Images_Meta::get( $post_id_2 ) );
 
-		$deleted_rows = Post_Images_Meta::delete_all();
+		$deleted = Post_Images_Meta::delete_all();
 
-		// Clear meta cache because we're bypassing WordPress with $wpdb->delete
-		wp_cache_delete( $post_id_1, 'post_meta' );
-		wp_cache_delete( $post_id_2, 'post_meta' );
-
-		$this->assertGreaterThanOrEqual( 2, $deleted_rows );
+		$this->assertTrue( $deleted );
 		$this->assertEmpty( Post_Images_Meta::get( $post_id_1 ), 'Post 1 meta should be empty' );
 		$this->assertEmpty( Post_Images_Meta::get( $post_id_2 ), 'Post 2 meta should be empty' );
 	}

--- a/uninstall.php
+++ b/uninstall.php
@@ -9,13 +9,14 @@ if ( ! empty( $options['remove_on_uninstall'] ) ) {
 	global $wpdb;
 
 	// delete post meta fields
-	$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => 'isc_post_images' ), array( '%s' ) );
-	$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => 'isc_image_posts' ), array( '%s' ) );
-	$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => 'isc_image_source' ), array( '%s' ) );
-	$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => 'isc_image_source_own' ), array( '%s' ) );
-	$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => 'isc_image_source_url' ), array( '%s' ) );
-	$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => 'isc_possible_usages' ), array( '%s' ) );
-	$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => 'isc_possible_usages_last_check' ), array( '%s' ) );
+	delete_post_meta_by_key( 'isc_post_images' );
+	delete_post_meta_by_key( 'isc_image_posts' );
+	delete_post_meta_by_key( 'isc_image_source' );
+	delete_post_meta_by_key( 'isc_image_source_own' );
+	delete_post_meta_by_key( 'isc_image_source_url' );
+	delete_post_meta_by_key( 'isc_possible_usages' );
+	delete_post_meta_by_key( 'isc_possible_usages_last_check' );
+	delete_post_meta_by_key( 'isc_post_images_before_update' );
 
 	// delete main plugin options
 	delete_option( 'isc_options' );


### PR DESCRIPTION
Replacing some direct database calls for removing post meta with appropriate WordPress methods.

Adjusting some related methods and tests.