### PR TITLE
Make per-page list extendable

### DIFF
--- a/admin/templates/settings/page-list/layout.php
+++ b/admin/templates/settings/page-list/layout.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Render layout settings for the Per-page lists in the content
+ *
+ * @var bool $list_layout_details value of the list_layout[details] option.
+ * @var bool $is_pro_enabled whether the Pro version is enabled.
+ */
+
+?>
+<div class="isc-settings-highlighted">
+<label>
+	<input type="checkbox" name="isc_options[list_layout][details]" value="1" <?php checked( $list_layout_details ); ?> <?php echo ! $is_pro_enabled ? 'disabled="disabled"' : ''; ?>/>
+	<?php
+	if ( ! $is_pro_enabled ) :
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo ISC\Admin_Utils::get_pro_link( 'page-list-layout-details' );
+endif;
+	?>
+	<?php
+	esc_html_e( 'Expandable list', 'image-source-control-isc' );
+	?>
+</label>
+<p class="description">
+	<?php
+	esc_html_e( 'Show as an expandable list that opens on click.', 'image-source-control-isc' );
+	?>
+</div>
+<?php

--- a/includes/settings/sections/page-list.php
+++ b/includes/settings/sections/page-list.php
@@ -16,6 +16,7 @@ class Page_List extends Settings\Section {
 		add_settings_section( 'isc_settings_section_list_below_content', __( 'Per-page list', 'image-source-control-isc' ), [ $this, 'render_settings_section' ], 'isc_settings_page' );
 		add_settings_field( 'source_type_list', __( 'Enable', 'image-source-control-isc' ), [ $this, 'render_field_source_type_list' ], 'isc_settings_page', 'isc_settings_section_list_below_content' );
 		add_settings_field( 'image_list_headline', __( 'Headline', 'image-source-control-isc' ), [ $this, 'render_field_list_headline' ], 'isc_settings_page', 'isc_settings_section_list_below_content' );
+		add_settings_field( 'list_layout', __( 'Layout', 'image-source-control-isc' ), [ $this, 'render_field_list_layout' ], 'isc_settings_page', 'isc_settings_section_list_below_content' );
 		add_settings_field( 'below_content_included_images', __( 'Included images', 'image-source-control-isc' ), [ $this, 'render_field_below_content_included_images' ], 'isc_settings_page', 'isc_settings_section_list_below_content' );
 	}
 
@@ -40,6 +41,16 @@ class Page_List extends Settings\Section {
 	public function render_field_list_headline() {
 		$options = $this->get_options();
 		require_once ISCPATH . '/admin/templates/settings/page-list/headline.php';
+	}
+
+	/**
+	 * Render option to define the layout of the image list
+	 */
+	public function render_field_list_layout() {
+		$options             = $this->get_options();
+		$list_layout_details = ! empty( ( $options['list_layout'] ?? [] )['details'] ?? false );
+		$is_pro_enabled      = \ISC\Plugin::is_pro();
+		require_once ISCPATH . '/admin/templates/settings/page-list/layout.php';
 	}
 
 	/**

--- a/lib/composer/autoload_classmap.php
+++ b/lib/composer/autoload_classmap.php
@@ -36,6 +36,7 @@ return array(
     'ISC\\Plugin' => $baseDir . '/includes/plugin.php',
     'ISC\\Pro\\Custom_Attribute_Processor' => $baseDir . '/pro/includes/Custom_Attribute_Processor.php',
     'ISC\\Pro\\IPTC' => $baseDir . '/pro/includes/IPTC.php',
+    'ISC\\Pro\\List_Layout_Details' => $baseDir . '/pro/includes/List_Layout_Details.php',
     'ISC\\Settings' => $baseDir . '/includes/settings.php',
     'ISC\\Settings\\Section' => $baseDir . '/includes/settings/section.php',
     'ISC\\Settings\\Sections\\Caption' => $baseDir . '/includes/settings/sections/caption.php',

--- a/lib/composer/autoload_static.php
+++ b/lib/composer/autoload_static.php
@@ -56,6 +56,7 @@ class ComposerStaticInitdb72a6bac11cb0e6b971811c93d09a9b
         'ISC\\Plugin' => __DIR__ . '/../..' . '/includes/plugin.php',
         'ISC\\Pro\\Custom_Attribute_Processor' => __DIR__ . '/../..' . '/pro/includes/Custom_Attribute_Processor.php',
         'ISC\\Pro\\IPTC' => __DIR__ . '/../..' . '/pro/includes/IPTC.php',
+        'ISC\\Pro\\List_Layout_Details' => __DIR__ . '/../..' . '/pro/includes/List_Layout_Details.php',
         'ISC\\Settings' => __DIR__ . '/../..' . '/includes/settings.php',
         'ISC\\Settings\\Section' => __DIR__ . '/../..' . '/includes/settings/section.php',
         'ISC\\Settings\\Sections\\Caption' => __DIR__ . '/../..' . '/includes/settings/sections/caption.php',

--- a/public/public.php
+++ b/public/public.php
@@ -512,13 +512,9 @@ class ISC_Public extends \ISC\Image_Sources\Image_Sources {
 			return '';
 		}
 
-		$options  = $this->get_options();
-		$headline = $options['image_list_headline'];
-
 		ob_start();
 
 		?>
-			<p class="isc_image_list_title"><?php echo esc_html( $headline ); ?></p>
 			<ul class="isc_image_list">
 		<?php
 
@@ -946,14 +942,26 @@ class ISC_Public extends \ISC\Image_Sources\Image_Sources {
 	 * dedicated to displaying an empty box as well so don’t add more visible elements
 	 *
 	 * @param string $content content of the source box, i.e., list of sources.
+	 * @param bool   $create_placeholder if true, create a placeholder box without content.
 	 */
-	public function render_image_source_box( $content = null ) {
+	public function render_image_source_box( string $content = '', bool $create_placeholder = false ): string {
+		$options  = $this->get_options();
+		$headline = $options['image_list_headline'];
+
 		ob_start();
 		require ISCPATH . 'public/views/image-source-box.php';
 
 		ISC_Log::log( 'finished creating image source box' );
 
-		return ob_get_clean();
+		/**
+		 * Filter: isc_render_image_source_box
+		 * allow to modify the output of the image source box
+		 *
+		 * @param string $content content of the source box.
+		 * @param string $headline headline of the source box.
+		 * @param bool   $create_placeholder if true, create a placeholder box without content.
+		 */
+		return apply_filters( 'isc_render_image_source_box', ob_get_clean(), $content, $headline, $create_placeholder );
 	}
 
 	/**

--- a/public/views/image-source-box.php
+++ b/public/views/image-source-box.php
@@ -5,6 +5,12 @@
  * Do not change the file. The styling is exactly as needed also to create an empty box as a placeholder.
  *
  * @var string $content list of image source or other content.
+ * @var string $headline headline for the image list.
+ * @var bool   $create_placeholder whether to create a placeholder or not.
  */
+
 ?>
-<div class="isc_image_list_box"><?php echo isset( $content ) ? $content : ''; ?></div>
+<div class="isc_image_list_box"><?php if ( ! $create_placeholder ) : ?>
+	<p class="isc_image_list_title"><?php echo esc_html( $headline ); ?></p>
+	<?php echo $content; ?>
+<?php endif; ?></div>

--- a/tests/wpunit/pro/includes/List_Layout_Details_Test.php
+++ b/tests/wpunit/pro/includes/List_Layout_Details_Test.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace ISC\Tests\WPUnit\Pro\Includes;
+
+use ISC\Pro\List_Layout_Details;
+use ISC_Public;
+use ISC\Tests\WPUnit\WPTestCase;
+
+class List_Layout_Details_Test extends WPTestCase {
+
+	protected $list_layout_details_instance;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// Initialize with the feature off by default for tests
+		update_option( 'isc_options', array_merge( \ISC\Plugin::get_options(), [
+			//'enable_image_sources' => true, // Ensure the main module is on
+			'image_list_headline'  => 'Test Headline',
+			'list_layout'          => [ 'details' => false ],
+		] ) );
+
+		// Instantiate the class responsible for the <details> layout
+		$this->list_layout_details_instance = new List_Layout_Details();
+	}
+
+	public function tearDown(): void {
+		// Clean up options
+		delete_option( 'isc_options' );
+
+		remove_filter( 'isc_image_list_box_tag', [ $this->list_layout_details_instance, 'change_tag_to_details_for_testing' ], 10 );
+		remove_filter( 'isc_render_image_source_box', [ $this->list_layout_details_instance, 'render_image_source_box' ], 10 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Helper to activate or deactivate the 'details' layout option
+	 * and ensure hooks are registered/deregistered accordingly.
+	 */
+	private function set_details_layout_active( bool $active ) {
+		$options                           = (array) get_option( 'isc_options' );
+		$options['list_layout']['details'] = $active;
+		update_option( 'isc_options', $options );
+
+		// Manually call register_hooks() to simulate the 'wp' action
+		// based on the current option state. This is crucial because
+		// the hooks are conditional on this option.
+		$this->list_layout_details_instance->register_hooks();
+	}
+
+	/**
+	 * Test if the details layout option is inactive
+	 * this is the default state and should output the <div> layout
+	 *
+	 * @return void
+	 */
+	public function test_frontend_renders_base_div_layout_when_option_is_inactive() {
+		$public_base_instance = ISC_Public::get_instance();
+		$test_content         = '<ul><li>Source Item for Div</li></ul>';
+
+		$output = $public_base_instance->render_image_source_box( $test_content, false );
+
+		$this->assertStringContainsString( '<div class="isc_image_list_box">', $output, "Output should contain base <div> tag." );
+		$this->assertStringContainsString( '<p class="isc_image_list_title">Test Headline</p>', $output, "Output should contain base <p> headline." );
+		$this->assertStringContainsString( $test_content, $output, "Output should contain the provided content." );
+		$this->assertStringContainsString( '</div>', $output, "Output should close with </div> tag." );
+		$this->assertStringNotContainsString( '<details', $output, "Output should NOT contain <details> tag when option is inactive." );
+		$this->assertStringNotContainsString( '<summary', $output, "Output should NOT contain <summary> tag when option is inactive." );
+	}
+
+	/**
+	 * Test if the details layout option is active
+	 *
+	 * @return void
+	 */
+	public function test_frontend_renders_details_layout_when_option_is_active() {
+		$this->set_details_layout_active( true );
+		$public_base_instance = ISC_Public::get_instance();
+		$test_content         = '<ul><li>Source Item for Details</li></ul>';
+
+		$output = $public_base_instance->render_image_source_box( $test_content );
+
+		$this->assertStringContainsString( '<details class="isc_image_list_box">', $output, "Output should contain <details> tag." );
+		$this->assertStringContainsString( '<summary class="isc_image_list_title">Test Headline</summary>', $output, "Output should contain <summary> with headline." );
+		$this->assertStringContainsString( $test_content, $output, "Output should contain the provided content." );
+		$this->assertStringContainsString( '</details>', $output, "Output should close with </details> tag." );
+		$this->assertStringNotContainsString( '<div class="isc_image_list_box">', $output, "Output should NOT contain base <div> wrapper when details is active." );
+		$this->assertStringNotContainsString( '<p class="isc_image_list_title">', $output, "Output should NOT contain base <p> headline when details is active." );
+	}
+
+	/**
+	 * Test if the <div> placeholder without content shows up if the details layout option is inactive
+	 *
+	 * @return void
+	 */
+	public function test_frontend_renders_base_div_placeholder_when_option_is_inactive() {
+		$public_base_instance = ISC_Public::get_instance();
+		$test_content         = '<ul><li>Source Item for Details</li></ul>';
+
+		// this is the line with the relevant change setting the second parameter to true
+		$output = $public_base_instance->render_image_source_box( $test_content, true );
+
+		$this->assertStringContainsString( '<div class="isc_image_list_box">', $output, "Placeholder should use base <div> tag." );
+		$this->assertStringNotContainsString( '<p class="isc_image_list_title">', $output, "Placeholder should not have a <p> headline." ); // As per base plugin's placeholder logic
+		$this->assertMatchesRegularExpression( '/<div class="isc_image_list_box">\s*<\/div>/s', $output, "Placeholder should be an empty <div> tag." );
+	}
+
+	/**
+	 * Test if the <details> placeholder without contant shows up if the details layout option is active
+	 *
+	 * @return void
+	 */
+	public function test_frontend_renders_details_placeholder_when_option_is_active() {
+		$this->set_details_layout_active( true );
+		$public_base_instance = ISC_Public::get_instance();
+		$test_content         = '<ul><li>Source Item for Details</li></ul>';
+
+		// this is the line with the relevant change setting the second parameter to true
+		$output = $public_base_instance->render_image_source_box( $test_content, true );
+
+		$this->assertStringContainsString( '<details class="isc_image_list_box">', $output, "Placeholder should use <details> tag." );
+		$this->assertStringNotContainsString( '<summary', $output, "Placeholder should not have a <summary>." );
+		$this->assertMatchesRegularExpression( '/<details class="isc_image_list_box">\s*<\/details>/s', $output, "Placeholder should be an empty <details> tag." );
+	}
+}


### PR DESCRIPTION
Added functions and filters to make the Per-page list extendable. E.g., in Pro, one can now choose to make the list collabsable.