### PR TITLE
Add overlay start split test

### DIFF
--- a/tests/wpunit/Pblc/Captions/Stop_Overlay_Test.php
+++ b/tests/wpunit/Pblc/Captions/Stop_Overlay_Test.php
@@ -34,10 +34,21 @@ class Stop_Overlay_Test extends WPTestCase {
 	 * Test if ISC_Public::add_source_captions_to_content() splits the content correctly when `isc_stop_overlay` exists
 	 * One image given in the HTML
 	 */
-	public function test_split_content_with_image() {
-		$html     = '<p>Some text</p><img src="https://example.com/image.jpg" alt="Image" /><div class="isc_stop_overlay"></div><p>Some more text</p>';
-		$expected = '<p>Some text</p><img src="https://example.com/image.jpg" alt="Image" /><div class=""></div><p>Some more text</p>';
-		$result   = ISC_Public::get_instance()->add_source_captions_to_content( $html );
-		$this->assertEquals( $expected, $result, 'Content with isc_stop_overlay and one image was not combined correctly' );
-	}
+        public function test_split_content_with_image() {
+                $html     = '<p>Some text</p><img src="https://example.com/image.jpg" alt="Image" /><div class="isc_stop_overlay"></div><p>Some more text</p>';
+                $expected = '<p>Some text</p><img src="https://example.com/image.jpg" alt="Image" /><div class=""></div><p>Some more text</p>';
+                $result   = ISC_Public::get_instance()->add_source_captions_to_content( $html );
+                $this->assertEquals( $expected, $result, 'Content with isc_stop_overlay and one image was not combined correctly' );
+        }
+
+       /**
+        * Test if ISC_Public::add_source_captions_to_content() splits the content correctly
+        * when `isc_stop_overlay` is at the very beginning of the content.
+        */
+       public function test_split_content_with_overlay_at_start() {
+               $html     = '<div class="isc_stop_overlay"></div><p>Some text</p>';
+               $expected = '<div class=""></div><p>Some text</p>';
+               $result   = ISC_Public::get_instance()->add_source_captions_to_content( $html );
+               $this->assertEquals( $expected, $result, 'Content starting with isc_stop_overlay was not handled correctly' );
+       }
 }


### PR DESCRIPTION
## Summary
- extend `Stop_Overlay_Test` with test for overlay marker at the start

## Testing
- `composer run-script wpunit` *(fails: composer not found)*
- `bash scripts/php-tests.sh wpunit` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483cb27ce08330ae68203f041d12de