### PR TITLE
Fix SRC comment typo

### DIFF
--- a/includes/image-sources/analyze-html.php
+++ b/includes/image-sources/analyze-html.php
@@ -147,7 +147,7 @@ class Analyze_HTML {
 		 * Look for any URLs
 		 * - starting with http, or https
 		 * - ending with a valid image format or " or '
-		 * - or any URL in the SRG attribute of IMG tags, where we ignore the extension
+                 * - or any URL in the SRC attribute of IMG tags, where we ignore the extension
 		 *
 		 * What it does
 		 * (?<!, ) – needed to prevent multiple images from `srcset` attribute to being considered here


### PR DESCRIPTION
## Summary
- fix a typo in the regex comment

## Testing
- `bash scripts/php-tests.sh wpunit` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68483cb581d48330a02e9960fc905585