### PR TITLE
Fix website URLs in PHPDoc

### DIFF
--- a/admin/utils.php
+++ b/admin/utils.php
@@ -59,8 +59,8 @@ class Admin_Utils {
 	 * Get URL to the ISC website by site language
 	 * If the URL param contains an anchor, the anchor will be added after the UTM part
 	 *
-	 * @param string $url_param    Default parameter added to the main URL, leading to https://imagesourceocontrol.com/.
-	 * @param string $url_param_de Parameter added to the main URL for German backends, leading to https://imagesourceocontrol.de/.
+         * @param string $url_param    Default parameter added to the main URL, leading to https://imagesourcecontrol.com/.
+         * @param string $url_param_de Parameter added to the main URL for German backends, leading to https://imagesourcecontrol.de/.
 	 * @param string $utm_campaign Position of the link for the campaign link.
 	 *
 	 * @return string website URL


### PR DESCRIPTION
## Summary
- fix broken domain names in `admin/utils.php`

## Testing
- `composer cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483cb792a88330a6123d760ac3205c