### PR TITLE
Prevent content from jumping on caption load

### DIFF
--- a/public/public.php
+++ b/public/public.php
@@ -183,6 +183,8 @@ class ISC_Public extends \ISC\Image_Sources\Image_Sources {
 		?>
 			<style>
 				.isc-source { position: relative; display: inline-block; line-height: initial; }
+				/* Hides the caption initially until it is positioned via JavaScript */
+				.isc-source > .isc-source-text { display: none; }
 				.wp-block-cover .isc-source { position: static; }
 				<?php
 				// The 2022 theme adds display:block to the featured image block, which creates additional line breaks. `display: inline` fixes that.


### PR DESCRIPTION
When rendering captions on pages that need longer to load or are uncached in the browser, the caption jumps when being positioned above the image

This solution is very simple. It hides the caption until it is loaded into position with JavaScript. Since the wrapper `isc-source` is included, which is always involved in rendering, this should never cause hidden sources, unless the user has some custom code.