### PR TITLE
Add standard source filter to Media Library

### DIFF
--- a/includes/image-sources/admin/media-library-filters.php
+++ b/includes/image-sources/admin/media-library-filters.php
@@ -31,6 +31,11 @@ class Admin_Media_Library_Filters {
 		];
 
 		$filters[] = [
+			'value' => 'standard_source',
+			'label' => __( 'Images with standard source', 'image-source-control-isc' ),
+		];
+
+		$filters[] = [
 			'value' => 'without_source',
 			'label' => __( 'Images without sources', 'image-source-control-isc' ),
 		];
@@ -76,6 +81,16 @@ class Admin_Media_Library_Filters {
 							'value'   => '',
 							'compare' => '!=',
 						],
+					],
+				]
+			);
+		} elseif ( $filter === 'standard_source' ) {
+			$query->set(
+				'meta_query',
+				[
+					[
+						'key'   => 'isc_image_source_own',
+						'value' => '1',
 					],
 				]
 			);

--- a/readme.txt
+++ b/readme.txt
@@ -53,7 +53,7 @@ Choose between different credit displays:
 * Warn about missing image sources
 * Manage, display, and link available licenses
 * Enable the features for any files in the media library or for images only
-* Filter the media library list by images with or without sources
+* Filter the media library list by images with or without sources, or only those using the standard source
 
 **Featured Image Caption**
 


### PR DESCRIPTION
## Summary
- allow filtering Media Library images by the standard source option
- update documentation about available filters
- fix indentation

## Testing
- `composer cs` *(fails: command not found)*
- `vendor/bin/codecept run tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab19325588330b02c14df9a44ac37