### PR TITLE
Added `svg` to the list of image file extensions

### DIFF
--- a/includes/image-sources/image-sources.php
+++ b/includes/image-sources/image-sources.php
@@ -21,6 +21,7 @@ class Image_Sources {
 		'jpeg',
 		'webp',
 		'avif',
+		'svg',
 	];
 
 	/**


### PR DESCRIPTION
I only added image file extensions to the list when the file format was naturally supported by WordPress. SVGs are not yet allowed as an upload into the media library. Though when a users allows it, they are handled properly and I didn’t find a reason not to whitelist them in general. This is only relevant for some features. They were already working for image sources when used in an `img` tag.