### PR TITLE
Check if guid value is correct

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -36,6 +36,7 @@ class Admin {
 	public function load_modules() {
 		new \ISC\Admin\Admin_Scripts();
 		new \ISC\Admin\Media_Library_Filter();
+		new \ISC\Admin\Media_Library_Checks();
 
 		if ( Plugin::is_module_enabled( 'image_sources' ) ) {
 			new \ISC\Image_Sources\Admin();

--- a/admin/includes/media-library-checks.php
+++ b/admin/includes/media-library-checks.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace ISC\Admin;
+
+use ISC\Helpers;
+
+/**
+ * Display a warning on the attachment edit screen when the GUID does not match
+ * the expected path.
+ */
+class Media_Library_Checks {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'add_meta_boxes', [ $this, 'add_warning_meta_box' ], 10, 2 );
+	}
+
+	/**
+	 * Add a warning meta box when the GUID domain or path does not match the attachment metadata.
+	 *
+	 * @param string   $post_type Post type.
+	 * @param \WP_Post $post      Attachment post object.
+	 */
+	public function add_warning_meta_box( $post_type, \WP_Post $post ) {
+		if ( 'attachment' !== $post_type ) {
+			return;
+		}
+
+		// Only add the meta box if there's any kind of GUID mismatch.
+		if ( $this->has_guid_domain_mismatch( $post ) || $this->has_guid_path_mismatch( $post ) ) {
+			add_meta_box(
+				'isc-error-check',
+				__( 'Error', 'image-source-control-isc' ),
+				[ $this, 'render_warning_meta_box' ],
+				'attachment',
+				'side',
+				'high'
+			);
+		}
+	}
+
+	/**
+	 * Determine if the GUID domain does not match the site's domain.
+	 *
+	 * @param \WP_Post $post Attachment post object.
+	 *
+	 * @return bool True if domain mismatched, false otherwise.
+	 */
+	public function has_guid_domain_mismatch( \WP_Post $post ): bool {
+		$host_guid = wp_parse_url( $post->guid, PHP_URL_HOST );
+		$host_site = wp_parse_url( home_url(), PHP_URL_HOST );
+
+		return $host_guid && $host_guid !== $host_site;
+	}
+
+	/**
+	 * Determine if the GUID path (directory part) does not match the expected path from metadata.
+	 * This comparison specifically ignores the filename itself, allowing for variations like '-scaled'.
+	 *
+	 * @param \WP_Post $post Attachment post object.
+	 *
+	 * @return bool True if path (directory) mismatched, false otherwise.
+	 */
+	public function has_guid_path_mismatch( \WP_Post $post ): bool {
+		$meta = Helpers::maybe_unserialize( get_post_meta( $post->ID, '_wp_attachment_metadata', true ) );
+		// Get the file path from metadata, remove leading slash for consistent pathinfo behavior.
+		$meta_file = isset( $meta['file'] ) ? ltrim( $meta['file'], '/' ) : '';
+
+		// If no meta file is available, we cannot determine a path mismatch.
+		if ( empty( $meta_file ) ) {
+			return false;
+		}
+
+		$path_guid    = wp_parse_url( $post->guid, PHP_URL_PATH );
+		$uploads_path = wp_parse_url( wp_get_upload_dir()['baseurl'], PHP_URL_PATH );
+
+		// Ensure uploads_path ends with a slash for consistent string manipulation.
+		if ( substr( $uploads_path, -1 ) !== '/' ) {
+			$uploads_path .= '/';
+		}
+
+		// Check if the GUID path starts with the uploads path. If not, it's a mismatch.
+		// This handles cases where the GUID points to a completely different base directory.
+		if ( strpos( $path_guid, $uploads_path ) !== 0 ) {
+			return true;
+		}
+
+		// Get the relative path and filename from the GUID, e.g., '2025/07/ai-image-929772310.jpg'.
+		$guid_relative_path_and_filename = substr( $path_guid, strlen( $uploads_path ) );
+
+		// Extract the directory part from both the meta file path and the GUID's relative path.
+		$meta_file_dirname     = pathinfo( $meta_file, PATHINFO_DIRNAME );
+		$guid_relative_dirname = pathinfo( $guid_relative_path_and_filename, PATHINFO_DIRNAME );
+
+		// If pathinfo returns '.' for the directory (meaning no directory part, just a filename),
+		// treat it as an empty string for consistent comparison.
+		if ( '.' === $meta_file_dirname ) {
+			$meta_file_dirname = '';
+		}
+		if ( '.' === $guid_relative_dirname ) {
+			$guid_relative_dirname = '';
+		}
+
+		// Compare the directory paths.
+		return $meta_file_dirname !== $guid_relative_dirname;
+	}
+
+	/**
+	 * Render the warning meta box content.
+	 * Displays specific warnings based on the type of GUID mismatch.
+	 *
+	 * @param \WP_Post $post Attachment post object.
+	 */
+	public function render_warning_meta_box( \WP_Post $post ) {
+		$domain_mismatch = $this->has_guid_domain_mismatch( $post );
+		$path_mismatch   = $this->has_guid_path_mismatch( $post );
+
+		if ( $domain_mismatch || $path_mismatch ) {
+			echo '<p style="color: red;">' .
+				esc_html__( 'The GUID URL does not match the site URL.', 'image-source-control-isc' ) . ' ' .
+				esc_html__( 'This might indicate a migration issue.', 'image-source-control-isc' ) .
+				'</p>';
+		}
+	}
+}

--- a/lib/composer/autoload_classmap.php
+++ b/lib/composer/autoload_classmap.php
@@ -9,6 +9,7 @@ return array(
     'Composer\\InstalledVersions' => $vendorDir . '/composer/InstalledVersions.php',
     'ISC\\Admin' => $baseDir . '/admin/admin.php',
     'ISC\\Admin\\Admin_Scripts' => $baseDir . '/admin/includes/scripts.php',
+    'ISC\\Admin\\Media_Library_Checks' => $baseDir . '/admin/includes/media-library-checks.php',
     'ISC\\Admin\\Media_Library_Filter' => $baseDir . '/admin/includes/media-library-filter.php',
     'ISC\\Admin_Utils' => $baseDir . '/admin/utils.php',
     'ISC\\Autoloader' => $baseDir . '/includes/class-autoloader.php',

--- a/lib/composer/autoload_static.php
+++ b/lib/composer/autoload_static.php
@@ -29,6 +29,7 @@ class ComposerStaticInitdb72a6bac11cb0e6b971811c93d09a9b
         'Composer\\InstalledVersions' => __DIR__ . '/..' . '/composer/InstalledVersions.php',
         'ISC\\Admin' => __DIR__ . '/../..' . '/admin/admin.php',
         'ISC\\Admin\\Admin_Scripts' => __DIR__ . '/../..' . '/admin/includes/scripts.php',
+        'ISC\\Admin\\Media_Library_Checks' => __DIR__ . '/../..' . '/admin/includes/media-library-checks.php',
         'ISC\\Admin\\Media_Library_Filter' => __DIR__ . '/../..' . '/admin/includes/media-library-filter.php',
         'ISC\\Admin_Utils' => __DIR__ . '/../..' . '/admin/utils.php',
         'ISC\\Autoloader' => __DIR__ . '/../..' . '/includes/class-autoloader.php',

--- a/tests/wpunit/Admin/Includes/Media_Library_Checks_Test.php
+++ b/tests/wpunit/Admin/Includes/Media_Library_Checks_Test.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace ISC\Tests\WPUnit\Admin\Includes;
+
+use ISC\Admin\Media_Library_Checks;
+use ISC\Tests\WPUnit\WPTestCase;
+use WP_Post;
+
+/**
+ * Test if ISC\Admin\Media_Type_Checker works as expected.
+ */
+class Media_Library_Checks_Test extends WPTestCase {
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Ensure home_url is consistent for this test.
+		update_option( 'home', 'https://localhost' );
+		update_option( 'siteurl', 'https://localhost' );
+	}
+
+	/**
+	 * Helper to create an attachment with specific GUID and metadata.
+	 *
+	 * @param string $guid     The GUID for the attachment.
+	 * @param array  $metadata The attachment metadata.
+	 *
+	 * @return array|null|WP_Post The created attachment post object.
+	 */
+	protected function create_attachment_with_data( string $guid, array $metadata = [] ) {
+		// Create a dummy post to attach the image to, if needed.
+		$parent_post_id = $this->factory()->post->create();
+
+		$attachment_id = wp_insert_attachment(
+			[
+				'post_title'     => 'Test Image ' . uniqid(),
+				'post_content'   => '',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/jpeg',
+				'guid'           => $guid,
+				'post_parent'    => $parent_post_id,
+			],
+			codecept_data_dir( 'test-image1.jpg' ), // Use one of the provided test images.
+			$parent_post_id
+		);
+
+		// Ensure the attachment was created successfully.
+		$this->assertIsInt( $attachment_id );
+		$this->assertGreaterThan( 0, $attachment_id );
+
+		// Update attachment metadata.
+		wp_update_attachment_metadata( $attachment_id, $metadata );
+
+		return get_post( $attachment_id );
+	}
+
+	/**
+	 * Test has_guid_domain_mismatch() returns true for different domains.
+	 */
+	public function test_has_guid_domain_mismatch_true(): void {
+		// Temporarily change home_url for this test to ensure a domain mismatch.
+		update_option( 'home', 'https://example.com' );
+		update_option( 'siteurl', 'https://example.com' );
+
+		$upload_dir = wp_get_upload_dir();
+		$file_path  = '2023/01/test-image1.jpg';
+		// Create a GUID with a different domain.
+		$guid       = 'https://different-domain.com' . $upload_dir['baseurl'] . '/' . $file_path;
+		$metadata   = [ 'file' => $file_path ];
+
+		$attachment = $this->create_attachment_with_data( $guid, $metadata );
+
+		$result = (new Media_Library_Checks() )->has_guid_domain_mismatch( $attachment );
+
+		$this->assertTrue( $result, 'Expected GUID domain mismatch to be true.' );
+	}
+
+	/**
+	 * Test has_guid_domain_mismatch() returns false for matching domains.
+	 */
+	public function test_has_guid_domain_mismatch_false(): void {
+		$file_path  = '2023/01/test-image1.jpg';
+		$guid       = home_url() . '/wp-content/uploads/' . $file_path; // GUID matches home_url.
+		$metadata   = [ 'file' => $file_path ];
+
+		$attachment = $this->create_attachment_with_data( $guid, $metadata );
+
+		$result = (new Media_Library_Checks() )->has_guid_domain_mismatch( $attachment );
+
+		$this->assertFalse( $result, 'Expected GUID domain mismatch to be false for matching domains.' );
+	}
+
+	/**
+	 * Test has_guid_domain_mismatch() returns false if GUID has no host (e.g., relative path).
+	 */
+	public function test_has_guid_domain_mismatch_no_host_in_guid(): void {
+		$file_path = '2023/01/test-image1.jpg';
+		$guid      = '/wp-content/uploads/' . $file_path; // Relative GUID, no host.
+		$metadata  = [ 'file' => $file_path ];
+
+		$attachment = $this->create_attachment_with_data( $guid, $metadata );
+
+		$result = (new Media_Library_Checks() )->has_guid_domain_mismatch( $attachment );
+
+		$this->assertFalse( $result, 'Expected GUID domain mismatch to be false for relative GUID.' );
+	}
+
+	/**
+	 * Test has_guid_path_mismatch() returns true for different directory paths.
+	 */
+	public function test_has_guid_path_mismatch_true_different_directory(): void {
+		// GUID points to a different month directory.
+		$guid     = home_url() . '/wp-content/uploads/2023/02/test-image1.jpg';
+		$metadata = [ 'file' => '2023/01/test-image1.jpg' ];
+
+		$attachment = $this->create_attachment_with_data( $guid, $metadata );
+
+		$result = (new Media_Library_Checks() )->has_guid_path_mismatch( $attachment );
+
+		$this->assertTrue( $result, 'Expected GUID path mismatch to be true for different directories.' );
+	}
+
+	/**
+	 * Test has_guid_path_mismatch() returns false for same directory path, even with '-scaled' suffix.
+	 */
+	public function test_has_guid_path_mismatch_false_same_directory_scaled_image(): void {
+		// GUID points to a scaled version in the same directory.
+		$guid     = home_url() . '/wp-content/uploads/2023/01/test-image1-scaled.jpg';
+		$metadata = [ 'file' => '2023/01/test-image1.jpg' ];
+
+		$attachment = $this->create_attachment_with_data( $guid, $metadata );
+
+		$result = (new Media_Library_Checks() )->has_guid_path_mismatch( $attachment );
+
+		$this->assertFalse( $result, 'Expected GUID path mismatch to be false for scaled image in same directory.' );
+	}
+
+	/**
+	 * Test has_guid_path_mismatch() returns false for matching directory paths and filenames.
+	 */
+	public function test_has_guid_path_mismatch_false_same_directory_original_image(): void {
+		$guid     = home_url() . '/wp-content/uploads/2023/01/test-image1.jpg';
+		$metadata = [ 'file' => '2023/01/test-image1.jpg' ];
+
+		$attachment = $this->create_attachment_with_data( $guid, $metadata );
+
+		$result = (new Media_Library_Checks() )->has_guid_path_mismatch( $attachment );
+
+		$this->assertFalse( $result, 'Expected GUID path mismatch to be false for matching paths.' );
+	}
+
+	/**
+	 * Test has_guid_path_mismatch() returns false if _wp_attachment_metadata is missing 'file'.
+	 */
+	public function test_has_guid_path_mismatch_no_meta_file(): void {
+		$guid     = home_url() . '/wp-content/uploads/2023/01/test-image1.jpg';
+		$metadata = []; // No 'file' key.
+
+		$attachment = $this->create_attachment_with_data( $guid, $metadata );
+
+		$result = (new Media_Library_Checks() )->has_guid_path_mismatch( $attachment );
+
+		$this->assertFalse( $result, 'Expected GUID path mismatch to be false when meta file is missing.' );
+	}
+
+	/**
+	 * Test has_guid_path_mismatch() returns false if _wp_attachment_metadata 'file' is empty.
+	 */
+	public function test_has_guid_path_mismatch_empty_meta_file(): void {
+		$guid     = home_url() . '/wp-content/uploads/2023/01/test-image1.jpg';
+		$metadata = [ 'file' => '' ]; // Empty 'file' key.
+
+		$attachment = $this->create_attachment_with_data( $guid, $metadata );
+
+		$result = (new Media_Library_Checks() )->has_guid_path_mismatch( $attachment );
+
+		$this->assertFalse( $result, 'Expected GUID path mismatch to be false when meta file is empty.' );
+	}
+
+	/**
+	 * Test has_guid_path_mismatch() returns true if GUID path is outside the uploads directory.
+	 */
+	public function test_has_guid_path_mismatch_guid_outside_uploads_dir(): void {
+		// GUID points to a path not starting with the uploads base URL path.
+		$guid      = home_url() . '/some-other-dir/2023/01/test-image1.jpg';
+		$metadata  = [ 'file' => '2023/01/test-image1.jpg' ];
+
+		$attachment = $this->create_attachment_with_data( $guid, $metadata );
+
+		$result = (new Media_Library_Checks() )->has_guid_path_mismatch( $attachment );
+
+		$this->assertTrue( $result, 'Expected GUID path mismatch to be true when GUID is outside uploads directory.' );
+	}
+}


### PR DESCRIPTION
Added a meta box to the media library single image view to list warnings.

The two checks added are about mismatching values for `wp_posts.guid` with the file path.

A mismatch can happen after a domain was moved. It would influence part of the fallback lookup for images.

The warning is visible at the top right of the screenshot.

<img width="1750" height="718" alt="CleanShot 2025-07-22 at 11 42 35" src="https://github.com/user-attachments/assets/aac32ec6-0e7e-4080-b1de-385aa0f65c02" />
