### PR TITLE
Disable isc_storage autoload

### DIFF
--- a/includes/storage-model.php
+++ b/includes/storage-model.php
@@ -178,7 +178,8 @@ class ISC_Storage_Model {
 		}
 
 		$this->storage = $storage;
-		update_option( $this->option_slug, $storage, true );
+		// autoload is false since this can get quite large
+		update_option( $this->option_slug, $storage, false );
 	}
 
 	/**


### PR DESCRIPTION
Disables the `isc_storage` autoload. The effect depends on the individual setup of the site. See #337 for more information.

Fixes #337