### PR TITLE
Extended ISC_Log

### DIFF
--- a/includes/log.php
+++ b/includes/log.php
@@ -127,6 +127,15 @@ class ISC_Log {
 	}
 
 	/**
+	 * Return true if existing indexer data (Pro) should be ignored
+	 * only works in combination with an activated log
+	 */
+	public static function ignore_index(): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification
+		return self::enabled() && isset( $_GET['isc-ignore-index'] );
+	}
+
+	/**
 	 * Return true if the log should be cleared automatically before writing
 	 */
 	public static function clear_log(): bool {


### PR DESCRIPTION
The new parameter is used in the Indexer in Pro to prevent ISC using an existing index. This helps analyse how a new index is processed.