### PR TITLE
Link to Global List styling tips

### DIFF
--- a/admin/templates/settings/global-list/layout.php
+++ b/admin/templates/settings/global-list/layout.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Render the Layout option for the Global List.
+ *
+ * Practically, there are no options here, but users regularly ask for layout tips, so we included the link to the manual here.
+ *
+ * @var string $manual_url URL to the manual page for this setting.
+ */
+
+?>
+<p>
+	<a href="<?php echo esc_url( $manual_url ); ?>" target="_blank"><?php esc_html_e( 'Manual', 'image-source-control-isc' ); ?></a>
+</p>

--- a/includes/settings/sections/global-list.php
+++ b/includes/settings/sections/global-list.php
@@ -17,6 +17,7 @@ class Global_List extends Settings\Section {
 		add_settings_section( 'isc_settings_section_complete_list', __( 'Global list', 'image-source-control-isc' ), [ $this, 'render_settings_section' ], 'isc_settings_page' );
 		add_settings_field( 'global_list_included_images', __( 'Included images', 'image-source-control-isc' ), [ $this, 'render_field_global_list_included_images' ], 'isc_settings_page', 'isc_settings_section_complete_list' );
 		add_settings_field( 'images_per_page_in_list', __( 'Images per page', 'image-source-control-isc' ), [ $this, 'render_field_images_per_page_in_list' ], 'isc_settings_page', 'isc_settings_section_complete_list' );
+		add_settings_field( 'global_list_layout', __( 'Layout', 'image-source-control-isc' ), [ $this, 'render_field_global_list_layout' ], 'isc_settings_page', 'isc_settings_section_complete_list' );
 		add_settings_field( 'global_list_included_data', __( 'Included data', 'image-source-control-isc' ), [ $this, 'render_field_global_list_data' ], 'isc_settings_page', 'isc_settings_section_complete_list' );
 	}
 
@@ -48,6 +49,18 @@ class Global_List extends Settings\Section {
 		$options         = $this->get_options();
 		$images_per_page = isset( $options['images_per_page'] ) ? absint( $options['images_per_page'] ) : 99999;
 		require_once ISCPATH . '/admin/templates/settings/global-list/images-per-page.php';
+	}
+
+	/**
+	 * Render option to define the layout of the global list
+	 */
+	public function render_field_global_list_layout() {
+		$manual_url = \ISC\Admin_Utils::get_isc_localized_website_url(
+			'documentation/customizations/#Styling_the_global_list',
+			'dokumentation/anpassungen/#Die_Globale_Quellenliste_stylen',
+			'global-list-layout'
+		);
+		require_once ISCPATH . '/admin/templates/settings/global-list/layout.php';
 	}
 
 	/**


### PR DESCRIPTION
Users ask from time to time how to style the Global List. There are no dedicated options, so I linked to the styling tips in the manual now in a new Layout section in the Global List settings.

<img width="773" height="155" alt="CleanShot 2025-11-04 at 08 44 28" src="https://github.com/user-attachments/assets/ee939a3f-4012-47f3-8bde-cb3e6fccc97d" />
