### PR TITLE
Fixed pagination only showing 10 results when chosing 0 in the settings.

### DIFF
--- a/includes/image-sources/renderer/global-list.php
+++ b/includes/image-sources/renderer/global-list.php
@@ -152,10 +152,10 @@ class Global_List extends Renderer {
 	/**
 	 * Get attachments based on the provided arguments
 	 *
-	 * @param array    $a        Shortcode attributes.
-	 * @param int|null $per_page Number of items per page.
-	 * @param int      $page     Current page number.
-	 * @param string   $included Which types of images to include ('all' or '').
+	 * @param array  $a        Shortcode attributes.
+	 * @param int    $per_page Number of items per page.
+	 * @param int    $page     Current page number.
+	 * @param string $included Which types of images to include ('all' or '').
 	 *
 	 * @return \WP_Query Returns a WP_Query object.
 	 */
@@ -205,7 +205,7 @@ class Global_List extends Renderer {
 		// Build default arguments
 		$args = [
 			'post_type'      => 'attachment',
-			'posts_per_page' => $per_page === 0 ? get_option( 'posts_per_page' ) : (int) $per_page,
+			'posts_per_page' => $per_page === 0 ? -1 : (int) $per_page,
 			'post_status'    => 'inherit',
 			'post_parent'    => null,
 			'paged'          => max( $page, 1 ),

--- a/tests/Acceptance/Pblc/Global_List/Global_List_Pagination_Cest.php
+++ b/tests/Acceptance/Pblc/Global_List/Global_List_Pagination_Cest.php
@@ -255,4 +255,23 @@ class Global_List_Pagination_Cest {
 			$I->amOnPage( '/?p=' . $postId );
 		}
 	}
+
+	/**
+	 * Test that setting the plugin option `images_per_page` to 0 shows all entries without pagination.
+	 *
+	 * @param \AcceptanceTester $I The acceptance tester instance.
+	 */
+	public function test_plugin_option_zero_shows_all_entries_without_pagination( \AcceptanceTester $I ) {
+		$existingOption                      = $I->grabOptionFromDatabase( 'isc_options' );
+		$existingOption['images_per_page']   = 0;
+		$I->haveOptionInDatabase( 'isc_options', $existingOption );
+
+		$I->amOnPage( '/global-list-option' );
+
+		for ( $i = 1; $i <= $this->number_of_images; $i++ ) {
+			$I->see( "Author $i" );
+		}
+
+		$I->dontSeeElement( '.page-numbers' );
+	}
 }


### PR DESCRIPTION
When a user set "0" as an option for the number of results in the global list, they showed 10 and no pagination. This was against the description of the option.

Adds an appropriate test as well.

Fixes #455